### PR TITLE
Add CSRF protection to frontend cart and checkout flows

### DIFF
--- a/frontend/actions/add_to_cart.php
+++ b/frontend/actions/add_to_cart.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../includes/bootstrap.php';
 require_once __DIR__ . '/../includes/cart_functions.php';
 require_once __DIR__ . '/../../includes/functions.php';
 
@@ -11,6 +12,13 @@ try {
 } catch (Throwable $e) {
     http_response_code(400);
     echo json_encode(['success' => false, 'message' => 'Invalid request body']);
+    exit;
+}
+
+$csrfToken = kidstore_frontend_extract_request_csrf_token();
+if (!kidstore_frontend_csrf_validate($csrfToken)) {
+    http_response_code(419);
+    echo json_encode(['success' => false, 'message' => 'Security token mismatch. Please refresh and try again.']);
     exit;
 }
 

--- a/frontend/actions/place_order.php
+++ b/frontend/actions/place_order.php
@@ -26,6 +26,13 @@ $fields = [
     'payment_method' => trim((string) ($_POST['payment_method'] ?? 'Cash on Delivery')),
 ];
 
+if (!kidstore_frontend_csrf_validate($_POST[KIDSTORE_FRONTEND_CSRF_FIELD] ?? null)) {
+    $_SESSION['checkout_error'] = 'Your session has expired. Please refresh and try again.';
+    $_SESSION['checkout_form_data'] = $fields;
+    header('Location: ../pages/checkout.php');
+    exit;
+}
+
 if ($fields['name'] === '' || $fields['email'] === '' || !filter_var($fields['email'], FILTER_VALIDATE_EMAIL)) {
     $_SESSION['checkout_error'] = 'Please provide a valid name and email address.';
     $_SESSION['checkout_form_data'] = $fields;

--- a/frontend/actions/update_cart.php
+++ b/frontend/actions/update_cart.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../includes/bootstrap.php';
 require_once __DIR__ . '/../includes/cart_functions.php';
 require_once __DIR__ . '/../../includes/functions.php';
 
@@ -11,6 +12,13 @@ try {
 } catch (Throwable $e) {
     http_response_code(400);
     echo json_encode(['success' => false, 'message' => 'Invalid request body']);
+    exit;
+}
+
+$csrfToken = kidstore_frontend_extract_request_csrf_token();
+if (!kidstore_frontend_csrf_validate($csrfToken)) {
+    http_response_code(419);
+    echo json_encode(['success' => false, 'message' => 'Security token mismatch. Please refresh and try again.']);
     exit;
 }
 

--- a/frontend/assets/script.js
+++ b/frontend/assets/script.js
@@ -7,6 +7,16 @@
         return el;
     }
 
+    function buildJsonHeaders() {
+        const headers = { 'Content-Type': 'application/json' };
+        const token = window.KIDSTORE_CSRF_TOKEN;
+        if (token) {
+            const headerName = window.KIDSTORE_CSRF_HEADER || 'X-Kidstore-CSRF';
+            headers[headerName] = token;
+        }
+        return headers;
+    }
+
     function showNotification(message, isError) {
         const el = getNotificationElement();
         if (!el) {
@@ -56,7 +66,7 @@
             const basePath = window.KIDSTORE_FRONT_PREFIX || '';
             fetch(`${basePath}actions/add_to_cart.php`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: buildJsonHeaders(),
                 body: JSON.stringify({ productId: parseInt(productId, 10), quantity: 1 })
             })
                 .then((response) => response.json())
@@ -110,4 +120,5 @@
     window.kidstoreShowNotification = showNotification;
     window.kidstoreUpdateCartBadge = updateCartBadge;
     window.kidstoreSetupAddToCartButtons = setupAddToCartButtons;
+    window.kidstoreBuildJsonHeaders = buildJsonHeaders;
 })();

--- a/frontend/includes/bootstrap.php
+++ b/frontend/includes/bootstrap.php
@@ -19,3 +19,67 @@ if (!defined('KIDSTORE_FRONT_URL_PREFIX')) {
     define('KIDSTORE_FRONT_URL_PREFIX', $prefix);
 }
 
+const KIDSTORE_FRONTEND_CSRF_SESSION_KEY = 'kidstore_frontend_csrf_token';
+const KIDSTORE_FRONTEND_CSRF_FIELD = 'kidstore_csrf_token';
+const KIDSTORE_FRONTEND_CSRF_HEADER = 'X-Kidstore-CSRF';
+
+if (!function_exists('kidstore_frontend_csrf_token')) {
+    /**
+     * Retrieve or generate a CSRF token for the current frontend session.
+     */
+    function kidstore_frontend_csrf_token(): string
+    {
+        $token = $_SESSION[KIDSTORE_FRONTEND_CSRF_SESSION_KEY] ?? null;
+        if (!is_string($token) || $token === '') {
+            $token = bin2hex(random_bytes(32));
+            $_SESSION[KIDSTORE_FRONTEND_CSRF_SESSION_KEY] = $token;
+        }
+
+        return $token;
+    }
+}
+
+if (!function_exists('kidstore_frontend_csrf_validate')) {
+    /**
+     * Validate a CSRF token against the session value.
+     */
+    function kidstore_frontend_csrf_validate(?string $token): bool
+    {
+        if (!is_string($token) || $token === '') {
+            return false;
+        }
+
+        $sessionToken = $_SESSION[KIDSTORE_FRONTEND_CSRF_SESSION_KEY] ?? null;
+        if (!is_string($sessionToken) || $sessionToken === '') {
+            return false;
+        }
+
+        return hash_equals($sessionToken, $token);
+    }
+}
+
+if (!function_exists('kidstore_frontend_extract_request_csrf_token')) {
+    /**
+     * Attempt to extract a CSRF token from common request locations.
+     */
+    function kidstore_frontend_extract_request_csrf_token(): ?string
+    {
+        $candidates = [
+            $_SERVER['HTTP_' . str_replace('-', '_', strtoupper(KIDSTORE_FRONTEND_CSRF_HEADER))] ?? null,
+            $_SERVER['HTTP_X_CSRF_TOKEN'] ?? null,
+            $_POST[KIDSTORE_FRONTEND_CSRF_FIELD] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_string($candidate) && $candidate !== '') {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+}
+
+// Ensure a token exists for the current session.
+kidstore_frontend_csrf_token();
+

--- a/frontend/pages/cart.php
+++ b/frontend/pages/cart.php
@@ -12,6 +12,7 @@ $cartTotal = getCartTotal();
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="kidstore-csrf-token" content="<?= htmlspecialchars(kidstore_frontend_csrf_token(), ENT_QUOTES, 'UTF-8'); ?>" />
     <title>Your Cart - Little Stars</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet" />
     <link href="<?php echo $prefix; ?>assets/styles.css" rel="stylesheet" />
@@ -243,6 +244,17 @@ $cartTotal = getCartTotal();
         const updateBadge = typeof window.kidstoreUpdateCartBadge === 'function'
             ? window.kidstoreUpdateCartBadge
             : () => {};
+        const buildJsonHeaders = typeof window.kidstoreBuildJsonHeaders === 'function'
+            ? window.kidstoreBuildJsonHeaders
+            : function () {
+                const headers = { 'Content-Type': 'application/json' };
+                const token = window.KIDSTORE_CSRF_TOKEN;
+                if (token) {
+                    const headerName = window.KIDSTORE_CSRF_HEADER || 'X-Kidstore-CSRF';
+                    headers[headerName] = token;
+                }
+                return headers;
+            };
 
         function syncTotals(data) {
             if (typeof data.cartTotal === 'number') {
@@ -266,7 +278,7 @@ $cartTotal = getCartTotal();
                 }
                 fetch('<?php echo $prefix; ?>actions/update_cart.php', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: buildJsonHeaders(),
                     body: JSON.stringify({ action: 'update', productId, quantity })
                 })
                     .then(response => response.json())
@@ -296,7 +308,7 @@ $cartTotal = getCartTotal();
             button.addEventListener('click', () => {
                 fetch('<?php echo $prefix; ?>actions/update_cart.php', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: buildJsonHeaders(),
                     body: JSON.stringify({ action: 'remove', productId })
                 })
                     .then(response => response.json())
@@ -321,7 +333,7 @@ $cartTotal = getCartTotal();
             clearCartBtn.addEventListener('click', () => {
                 fetch('<?php echo $prefix; ?>actions/update_cart.php', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: buildJsonHeaders(),
                     body: JSON.stringify({ action: 'clear' })
                 })
                     .then(response => response.json())

--- a/frontend/pages/checkout.php
+++ b/frontend/pages/checkout.php
@@ -21,6 +21,7 @@ unset($_SESSION['checkout_error']);
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="kidstore-csrf-token" content="<?= htmlspecialchars(kidstore_frontend_csrf_token(), ENT_QUOTES, 'UTF-8'); ?>" />
     <title>Checkout - Little Stars</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet" />
     <link href="<?php echo $prefix; ?>assets/styles.css" rel="stylesheet" />
@@ -133,6 +134,7 @@ unset($_SESSION['checkout_error']);
                         </div>
                     <?php endif; ?>
                     <form action="<?php echo $prefix; ?>actions/place_order.php" method="post" class="checkout-form">
+                        <input type="hidden" name="<?= KIDSTORE_FRONTEND_CSRF_FIELD ?>" value="<?= htmlspecialchars(kidstore_frontend_csrf_token(), ENT_QUOTES, 'UTF-8'); ?>" />
                         <div class="form-grid">
                             <div class="form-group">
                                 <label for="name">Full Name</label>

--- a/frontend/partials/header.php
+++ b/frontend/partials/header.php
@@ -328,7 +328,9 @@ if (defined('KIDSTORE_FRONT_URL_PREFIX')) {
 </style>
 
 <script>
-window.KIDSTORE_FRONT_PREFIX = '<?php echo $prefix; ?>';
+window.KIDSTORE_FRONT_PREFIX = <?php echo json_encode($prefix, JSON_UNESCAPED_SLASHES); ?>;
+window.KIDSTORE_CSRF_TOKEN = <?php echo json_encode(kidstore_frontend_csrf_token(), JSON_UNESCAPED_SLASHES); ?>;
+window.KIDSTORE_CSRF_HEADER = <?php echo json_encode(KIDSTORE_FRONTEND_CSRF_HEADER, JSON_UNESCAPED_SLASHES); ?>;
 function toggleSearch() {
     const searchBar = document.getElementById('search-bar');
     searchBar.classList.toggle('active');


### PR DESCRIPTION
## Summary
- generate and expose a frontend CSRF token in the shared bootstrap so pages, forms, and scripts can access it
- require valid CSRF tokens in add-to-cart, update-cart, and place-order actions to block forged requests
- propagate the token through checkout forms and all fetch calls, including reusable helpers for AJAX headers

## Testing
- php -l frontend/includes/bootstrap.php
- php -l frontend/partials/header.php
- php -l frontend/pages/cart.php
- php -l frontend/pages/checkout.php
- php -l frontend/actions/add_to_cart.php
- php -l frontend/actions/update_cart.php
- php -l frontend/actions/place_order.php

------
https://chatgpt.com/codex/tasks/task_e_68d901a5ee488324a2ebfeb605565381