### PR TITLE
Unify customer and admin authentication UI

### DIFF
--- a/backend/auth/login.php
+++ b/backend/auth/login.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/../includes/admin_auth.php';
+require_once __DIR__ . '/../../includes/auth_layout.php';
 
 if (kidstore_admin_logged_in()) {
     header('Location: ../index.php');
@@ -34,84 +35,43 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $error = 'Invalid credentials or insufficient permissions.';
     }
 }
+kidstore_auth_page_open(
+    'Admin sign in - Little Stars',
+    'Sign in to the dashboard',
+    'Use your administrator credentials to manage the Little Stars store.',
+    ['badge' => 'Admin']
+);
+
+if ($error) {
+    kidstore_auth_error($error);
+}
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Admin Login - Kid Store</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
-    <link rel="stylesheet" href="../assets/admin.css" />
-    <style>
-        .login-wrapper {
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background: linear-gradient(135deg, #6366f1, #8b5cf6);
-        }
-        .login-card {
-            background: #fff;
-            padding: 40px;
-            border-radius: 20px;
-            box-shadow: 0 15px 40px rgba(15, 23, 42, 0.2);
-            width: min(420px, 92vw);
-        }
-        .login-card h1 {
-            margin: 0 0 20px;
-            font-size: 1.8rem;
-            text-align: center;
-        }
-        .login-card form {
-            display: grid;
-            gap: 16px;
-        }
-        .login-card label {
-            font-weight: 600;
-        }
-        .login-card input {
-            padding: 12px 14px;
-            border-radius: 12px;
-            border: 1px solid #d1d5db;
-            font-size: 1rem;
-        }
-        .login-card button {
-            margin-top: 10px;
-            background: linear-gradient(135deg, #6366f1, #8b5cf6);
-            color: #fff;
-            border: none;
-            padding: 12px;
-            border-radius: 12px;
-            font-weight: 600;
-            cursor: pointer;
-        }
-        .login-error {
-            background: #fee2e2;
-            color: #b91c1c;
-            padding: 10px 14px;
-            border-radius: 10px;
-            font-size: 0.95rem;
-        }
-    </style>
-</head>
-<body class="login-wrapper">
-    <div class="login-card">
-        <h1><i class="fas fa-star"></i> Kid Store Admin</h1>
-        <?php if ($error): ?>
-            <div class="login-error"><?= htmlspecialchars($error) ?></div>
-        <?php endif; ?>
-        <form method="post">
-            <div>
-                <label for="email">Email</label>
-                <input type="email" id="email" name="email" value="<?= htmlspecialchars($email) ?>" required />
-            </div>
-            <div>
-                <label for="password">Password</label>
-                <input type="password" id="password" name="password" required />
-            </div>
-            <button type="submit">Sign In</button>
-        </form>
+<form method="post" class="auth-form" novalidate>
+    <div class="auth-field">
+        <label class="auth-label" for="email">Email</label>
+        <input
+            type="email"
+            class="auth-input"
+            id="email"
+            name="email"
+            value="<?= htmlspecialchars($email) ?>"
+            required
+            autocomplete="email"
+        />
     </div>
-</body>
-</html>
+    <div class="auth-field">
+        <label class="auth-label" for="password">Password</label>
+        <input
+            type="password"
+            class="auth-input"
+            id="password"
+            name="password"
+            required
+            autocomplete="current-password"
+        />
+    </div>
+    <button type="submit" class="auth-submit">Sign in</button>
+</form>
+<?php
+$meta = kidstore_auth_meta('Need to head back?', 'Return to storefront', '../../frontend/index.php');
+kidstore_auth_page_close($meta);

--- a/frontend/pages/auth/login.php
+++ b/frontend/pages/auth/login.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../../includes/bootstrap.php';
+require_once __DIR__ . '/../../../includes/auth_layout.php';
 
 if (kidstore_current_user()) {
     if (kidstore_is_admin()) {
@@ -30,130 +31,42 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         exit;
     }
 }
+kidstore_auth_page_open(
+    'Log in - Little Stars',
+    'Welcome back',
+    'Enter your details to access your Little Stars account.'
+);
+
+if ($error) {
+    kidstore_auth_error($error);
+}
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Log in - Little Stars</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
-    <style>
-        body {
-            margin: 0;
-            font-family: 'Inter', 'Segoe UI', sans-serif;
-            background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
-            color: #1f2937;
-        }
-        .auth-wrapper {
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 1.5rem;
-        }
-        .auth-card {
-            width: min(420px, 100%);
-            background: rgba(255, 255, 255, 0.85);
-            backdrop-filter: blur(18px);
-            border-radius: 24px;
-            padding: 2.5rem;
-            box-shadow: 0 30px 60px rgba(79, 114, 205, 0.2);
-        }
-        .auth-card h1 {
-            margin: 0 0 0.75rem;
-            font-size: 2rem;
-            font-weight: 700;
-        }
-        .auth-card p {
-            margin: 0 0 1.8rem;
-            color: #6b7280;
-        }
-        .form-group {
-            margin-bottom: 1.25rem;
-        }
-        label {
-            display: block;
-            margin-bottom: 0.4rem;
-            font-weight: 600;
-            font-size: 0.95rem;
-        }
-        input[type="email"],
-        input[type="password"] {
-            width: 100%;
-            padding: 0.85rem 1rem;
-            border-radius: 14px;
-            border: 1px solid rgba(99, 102, 241, 0.18);
-            font-size: 1rem;
-            transition: box-shadow 0.2s ease, border 0.2s ease;
-        }
-        input:focus {
-            outline: none;
-            border-color: #6366f1;
-            box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.18);
-        }
-        .submit-btn {
-            width: 100%;
-            background: linear-gradient(135deg, #667eea, #764ba2);
-            color: #fff;
-            border: none;
-            border-radius: 16px;
-            padding: 0.95rem;
-            font-size: 1rem;
-            font-weight: 600;
-            cursor: pointer;
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
-        }
-        .submit-btn:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 18px 30px rgba(102, 126, 234, 0.25);
-        }
-        .auth-meta {
-            margin-top: 1.5rem;
-            text-align: center;
-            font-size: 0.95rem;
-        }
-        .auth-meta a {
-            color: #6366f1;
-            text-decoration: none;
-            font-weight: 600;
-        }
-        .auth-meta a:hover {
-            text-decoration: underline;
-        }
-        .error-box {
-            background: rgba(248, 113, 113, 0.15);
-            border: 1px solid rgba(239, 68, 68, 0.25);
-            color: #b91c1c;
-            padding: 0.9rem 1rem;
-            border-radius: 14px;
-            margin-bottom: 1.5rem;
-        }
-    </style>
-</head>
-<body>
-    <div class="auth-wrapper">
-        <div class="auth-card">
-            <h1>Welcome back</h1>
-            <p>Enter your credentials to access your Little Stars account.</p>
-            <?php if ($error): ?>
-                <div class="error-box"><?php echo htmlspecialchars($error); ?></div>
-            <?php endif; ?>
-            <form method="post" novalidate>
-                <div class="form-group">
-                    <label for="email">Email address</label>
-                    <input type="email" id="email" name="email" value="<?php echo htmlspecialchars($email); ?>" required />
-                </div>
-                <div class="form-group">
-                    <label for="password">Password</label>
-                    <input type="password" id="password" name="password" required />
-                </div>
-                <button type="submit" class="submit-btn">Log in</button>
-            </form>
-            <div class="auth-meta">
-                New to Little Stars? <a href="register.php">Create an account</a>
-            </div>
-        </div>
+<form method="post" class="auth-form" novalidate>
+    <div class="auth-field">
+        <label class="auth-label" for="email">Email address</label>
+        <input
+            type="email"
+            class="auth-input"
+            id="email"
+            name="email"
+            value="<?php echo htmlspecialchars($email); ?>"
+            required
+            autocomplete="email"
+        />
     </div>
-</body>
-</html>
+    <div class="auth-field">
+        <label class="auth-label" for="password">Password</label>
+        <input
+            type="password"
+            class="auth-input"
+            id="password"
+            name="password"
+            required
+            autocomplete="current-password"
+        />
+    </div>
+    <button type="submit" class="auth-submit">Log in</button>
+</form>
+<?php
+$meta = kidstore_auth_meta('New to Little Stars?', 'Create an account', 'register.php');
+kidstore_auth_page_close($meta);

--- a/frontend/pages/auth/register.php
+++ b/frontend/pages/auth/register.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../../includes/bootstrap.php';
+require_once __DIR__ . '/../../../includes/auth_layout.php';
 
 if (kidstore_current_user()) {
     header('Location: ../../index.php');
@@ -20,150 +21,66 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     $errors = $result['errors'];
 }
+kidstore_auth_page_open(
+    'Create an account - Little Stars',
+    'Join Little Stars',
+    'Create an account to save favourites, track orders, and unlock member-only perks.',
+    ['wide' => true]
+);
+
+if ($errors) {
+    kidstore_auth_error_list($errors);
+}
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Create an account - Little Stars</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
-    <style>
-        body {
-            margin: 0;
-            font-family: 'Inter', 'Segoe UI', sans-serif;
-            background: linear-gradient(135deg, #fdfcfb, #e2d1c3);
-            color: #1f2937;
-        }
-        .auth-wrapper {
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 1.5rem;
-        }
-        .auth-card {
-            width: min(460px, 100%);
-            background: rgba(255, 255, 255, 0.9);
-            backdrop-filter: blur(16px);
-            border-radius: 28px;
-            padding: 2.75rem;
-            box-shadow: 0 40px 70px rgba(170, 126, 84, 0.15);
-        }
-        .auth-card h1 {
-            margin: 0 0 0.75rem;
-            font-size: 2.1rem;
-            font-weight: 700;
-        }
-        .auth-card p {
-            margin: 0 0 2rem;
-            color: #6b7280;
-        }
-        .form-grid {
-            display: grid;
-            gap: 1.2rem;
-        }
-        label {
-            display: block;
-            margin-bottom: 0.45rem;
-            font-weight: 600;
-        }
-        input[type="text"],
-        input[type="email"],
-        input[type="password"] {
-            width: 100%;
-            padding: 0.85rem 1rem;
-            border-radius: 16px;
-            border: 1px solid rgba(249, 115, 22, 0.2);
-            background: rgba(255, 255, 255, 0.85);
-            font-size: 1rem;
-            transition: box-shadow 0.2s ease, border 0.2s ease;
-        }
-        input:focus {
-            outline: none;
-            border-color: #f97316;
-            box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.15);
-        }
-        .submit-btn {
-            width: 100%;
-            background: linear-gradient(135deg, #f97316, #facc15);
-            color: #fff;
-            border: none;
-            border-radius: 18px;
-            padding: 1rem;
-            font-size: 1.05rem;
-            font-weight: 600;
-            cursor: pointer;
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
-        }
-        .submit-btn:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 20px 35px rgba(249, 115, 22, 0.25);
-        }
-        .auth-meta {
-            margin-top: 1.8rem;
-            text-align: center;
-            font-size: 0.95rem;
-        }
-        .auth-meta a {
-            color: #f97316;
-            text-decoration: none;
-            font-weight: 600;
-        }
-        .auth-meta a:hover {
-            text-decoration: underline;
-        }
-        .error-list {
-            background: rgba(248, 113, 113, 0.12);
-            border: 1px solid rgba(239, 68, 68, 0.25);
-            color: #b91c1c;
-            padding: 1rem 1.2rem;
-            border-radius: 16px;
-            margin-bottom: 1.6rem;
-        }
-        .error-list ul {
-            margin: 0;
-            padding-left: 1.2rem;
-        }
-    </style>
-</head>
-<body>
-    <div class="auth-wrapper">
-        <div class="auth-card">
-            <h1>Join Little Stars</h1>
-            <p>Create an account to save favourites, track orders, and get member-only perks.</p>
-            <?php if ($errors): ?>
-                <div class="error-list">
-                    <ul>
-                        <?php foreach ($errors as $error): ?>
-                            <li><?php echo htmlspecialchars($error); ?></li>
-                        <?php endforeach; ?>
-                    </ul>
-                </div>
-            <?php endif; ?>
-            <form method="post" class="form-grid" novalidate>
-                <div>
-                    <label for="name">Full name</label>
-                    <input type="text" id="name" name="name" value="<?php echo htmlspecialchars($name); ?>" required />
-                </div>
-                <div>
-                    <label for="email">Email address</label>
-                    <input type="email" id="email" name="email" value="<?php echo htmlspecialchars($email); ?>" required />
-                </div>
-                <div>
-                    <label for="password">Password</label>
-                    <input type="password" id="password" name="password" required />
-                </div>
-                <div>
-                    <label for="confirm_password">Confirm password</label>
-                    <input type="password" id="confirm_password" name="confirm_password" required />
-                </div>
-                <button type="submit" class="submit-btn">Create account</button>
-            </form>
-            <div class="auth-meta">
-                Already have an account? <a href="login.php">Log in</a>
-            </div>
-        </div>
+<form method="post" class="auth-form" novalidate>
+    <div class="auth-field">
+        <label class="auth-label" for="name">Full name</label>
+        <input
+            type="text"
+            class="auth-input"
+            id="name"
+            name="name"
+            value="<?php echo htmlspecialchars($name); ?>"
+            required
+            autocomplete="name"
+        />
     </div>
-</body>
-</html>
+    <div class="auth-field">
+        <label class="auth-label" for="email">Email address</label>
+        <input
+            type="email"
+            class="auth-input"
+            id="email"
+            name="email"
+            value="<?php echo htmlspecialchars($email); ?>"
+            required
+            autocomplete="email"
+        />
+    </div>
+    <div class="auth-field">
+        <label class="auth-label" for="password">Password</label>
+        <input
+            type="password"
+            class="auth-input"
+            id="password"
+            name="password"
+            required
+            autocomplete="new-password"
+        />
+    </div>
+    <div class="auth-field">
+        <label class="auth-label" for="confirm_password">Confirm password</label>
+        <input
+            type="password"
+            class="auth-input"
+            id="confirm_password"
+            name="confirm_password"
+            required
+            autocomplete="new-password"
+        />
+    </div>
+    <button type="submit" class="auth-submit">Create account</button>
+</form>
+<?php
+$meta = kidstore_auth_meta('Already have an account?', 'Log in', 'login.php');
+kidstore_auth_page_close($meta);

--- a/includes/auth_layout.php
+++ b/includes/auth_layout.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Shared layout helpers for authentication screens.
+ */
+declare(strict_types=1);
+
+if (!function_exists('kidstore_auth_styles')) {
+    function kidstore_auth_styles(): void
+    {
+        ?>
+        <style>
+            :root {
+                color-scheme: light;
+            }
+            body {
+                margin: 0;
+                font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+                background: #f3f4f6;
+                color: #111827;
+            }
+            .auth-wrapper {
+                min-height: 100vh;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 2.5rem 1.5rem;
+                background: radial-gradient(circle at top left, rgba(129, 140, 248, 0.18), transparent 55%),
+                    radial-gradient(circle at bottom right, rgba(249, 168, 212, 0.18), transparent 45%),
+                    #f9fafb;
+            }
+            .auth-card {
+                width: min(420px, 100%);
+                background: rgba(255, 255, 255, 0.92);
+                border-radius: 22px;
+                padding: 2.5rem;
+                box-shadow: 0 25px 60px rgba(15, 23, 42, 0.12);
+                backdrop-filter: blur(18px);
+            }
+            .auth-card--wide {
+                width: min(520px, 100%);
+            }
+            .auth-badge {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.4rem;
+                padding: 0.3rem 0.75rem;
+                border-radius: 999px;
+                font-size: 0.75rem;
+                font-weight: 600;
+                letter-spacing: 0.05em;
+                text-transform: uppercase;
+                background: rgba(99, 102, 241, 0.12);
+                color: #4338ca;
+                margin-bottom: 1.25rem;
+            }
+            .auth-header {
+                margin-bottom: 2rem;
+            }
+            .auth-header h1 {
+                margin: 0 0 0.75rem;
+                font-size: 1.85rem;
+                font-weight: 700;
+            }
+            .auth-subtitle {
+                margin: 0;
+                color: #6b7280;
+                line-height: 1.5;
+            }
+            .auth-form {
+                display: grid;
+                gap: 1.15rem;
+            }
+            .auth-field {
+                display: grid;
+                gap: 0.45rem;
+            }
+            .auth-label {
+                font-weight: 600;
+                font-size: 0.95rem;
+                color: #1f2937;
+            }
+            .auth-input {
+                width: 100%;
+                padding: 0.85rem 1rem;
+                border-radius: 14px;
+                border: 1px solid rgba(99, 102, 241, 0.18);
+                font-size: 1rem;
+                transition: border-color 0.2s ease, box-shadow 0.2s ease;
+                background: rgba(255, 255, 255, 0.9);
+            }
+            .auth-input:focus {
+                outline: none;
+                border-color: #6366f1;
+                box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
+            }
+            .auth-submit {
+                width: 100%;
+                background: linear-gradient(135deg, #6366f1, #8b5cf6);
+                color: #fff;
+                border: none;
+                border-radius: 16px;
+                padding: 0.95rem 1rem;
+                font-size: 1rem;
+                font-weight: 600;
+                cursor: pointer;
+                transition: transform 0.15s ease, box-shadow 0.15s ease;
+            }
+            .auth-submit:hover {
+                transform: translateY(-1px);
+                box-shadow: 0 16px 32px rgba(99, 102, 241, 0.25);
+            }
+            .auth-submit:focus-visible {
+                outline: none;
+                box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.25);
+            }
+            .auth-meta {
+                margin-top: 2rem;
+                text-align: center;
+                font-size: 0.95rem;
+                color: #4b5563;
+            }
+            .auth-meta a {
+                color: #4f46e5;
+                font-weight: 600;
+                text-decoration: none;
+            }
+            .auth-meta a:hover {
+                text-decoration: underline;
+            }
+            .auth-error,
+            .auth-error-list {
+                border-radius: 14px;
+                padding: 0.95rem 1.1rem;
+                background: rgba(248, 113, 113, 0.14);
+                border: 1px solid rgba(239, 68, 68, 0.25);
+                color: #b91c1c;
+                font-size: 0.95rem;
+            }
+            .auth-error-list ul {
+                margin: 0;
+                padding-left: 1.2rem;
+            }
+            @media (max-width: 520px) {
+                .auth-card,
+                .auth-card--wide {
+                    padding: 2rem 1.75rem;
+                }
+            }
+        </style>
+        <?php
+    }
+
+    function kidstore_auth_page_open(string $documentTitle, string $heading, string $description = '', array $options = []): void
+    {
+        $cardClass = 'auth-card';
+        if (!empty($options['wide'])) {
+            $cardClass .= ' auth-card--wide';
+        }
+
+        $badge = $options['badge'] ?? null;
+        $subtitle = $description !== '' ? '<p class="auth-subtitle">' . htmlspecialchars($description, ENT_QUOTES, 'UTF-8') . '</p>' : '';
+
+        ?>
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            <title><?= htmlspecialchars($documentTitle, ENT_QUOTES, 'UTF-8') ?></title>
+            <link rel="preconnect" href="https://fonts.googleapis.com" />
+            <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+            <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+            <?php kidstore_auth_styles(); ?>
+        </head>
+        <body>
+            <div class="auth-wrapper">
+                <div class="<?= $cardClass ?>">
+                    <?php if ($badge): ?>
+                        <div class="auth-badge"><?= htmlspecialchars((string) $badge, ENT_QUOTES, 'UTF-8') ?></div>
+                    <?php endif; ?>
+                    <div class="auth-header">
+                        <h1><?= htmlspecialchars($heading, ENT_QUOTES, 'UTF-8') ?></h1>
+                        <?= $subtitle ?>
+                    </div>
+        <?php
+    }
+
+    function kidstore_auth_page_close(?string $metaHtml = null): void
+    {
+        if ($metaHtml !== null && $metaHtml !== '') {
+            echo '<div class="auth-meta">' . $metaHtml . '</div>';
+        }
+        ?>
+                </div>
+            </div>
+        </body>
+        </html>
+        <?php
+    }
+
+    function kidstore_auth_error(string $message): void
+    {
+        echo '<div class="auth-error">' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '</div>';
+    }
+
+    function kidstore_auth_error_list(array $messages): void
+    {
+        if (!$messages) {
+            return;
+        }
+
+        echo '<div class="auth-error-list"><ul>';
+        foreach ($messages as $message) {
+            echo '<li>' . htmlspecialchars((string) $message, ENT_QUOTES, 'UTF-8') . '</li>';
+        }
+        echo '</ul></div>';
+    }
+
+    function kidstore_auth_meta(string $text, string $linkText, string $linkHref): string
+    {
+        $escapedText = htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+        $escapedLinkText = htmlspecialchars($linkText, ENT_QUOTES, 'UTF-8');
+        $escapedLinkHref = htmlspecialchars($linkHref, ENT_QUOTES, 'UTF-8');
+
+        return $escapedText . ' <a href="' . $escapedLinkHref . '">' . $escapedLinkText . '</a>';
+    }
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Shared helper functions for the Kid Store project.
  */


### PR DESCRIPTION
## Summary
- add a shared authentication layout helper with a minimalist look and feel
- refactor customer login and register pages to use the shared components and consistent semantics
- update the admin login screen to reuse the shared UI and link back to the storefront
- strip a stray BOM from includes/functions.php so strict_types declarations load correctly

## Testing
- php -l includes/auth_layout.php
- php -l frontend/pages/auth/login.php
- php -l frontend/pages/auth/register.php
- php -l backend/auth/login.php

------
https://chatgpt.com/codex/tasks/task_e_68d8fb1c4a508324ae5c16515da32909