### PR TITLE
Enhance shop search recommendations and cart lifecycle

### DIFF
--- a/backend/bootstrap.php
+++ b/backend/bootstrap.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../config/database.php';
 require_once __DIR__ . '/../includes/functions.php';
 require_once __DIR__ . '/../includes/orders.php';
 require_once __DIR__ . '/../includes/admin.php';
+require_once __DIR__ . '/../includes/auth.php';
 if (!defined('KIDSTORE_ADMIN_URL_PREFIX')) {
     // $scriptName = str_replace('\\', '/', $_SERVER['SCRIPT_NAME'] ?? '');
     // $prefix = '';

--- a/backend/includes/admin_auth.php
+++ b/backend/includes/admin_auth.php
@@ -18,5 +18,5 @@ function kidstore_admin_require_login(): void
 
 function kidstore_admin_logout(): void
 {
-    unset($_SESSION['admin_id'], $_SESSION['admin_name']);
+    kidstore_logout();
 }

--- a/frontend/actions/update_cart.php
+++ b/frontend/actions/update_cart.php
@@ -25,9 +25,15 @@ if (!kidstore_frontend_csrf_validate($csrfToken)) {
 $action = $payload['action'] ?? null;
 $productId = isset($payload['productId']) ? (int) $payload['productId'] : null;
 
-if ($action === null || $productId === null) {
+if ($action === null) {
     http_response_code(422);
-    echo json_encode(['success' => false, 'message' => 'Missing action or product identifier']);
+    echo json_encode(['success' => false, 'message' => 'Missing action type']);
+    exit;
+}
+
+if (in_array($action, ['update', 'remove'], true) && $productId === null) {
+    http_response_code(422);
+    echo json_encode(['success' => false, 'message' => 'Missing product identifier']);
     exit;
 }
 

--- a/frontend/assets/shop.css
+++ b/frontend/assets/shop.css
@@ -249,6 +249,49 @@ body.shop-page {
   box-shadow: var(--shadow-soft);
 }
 
+.shop-recommendation {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  margin-bottom: 24px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  background: linear-gradient(
+    135deg,
+    rgba(129, 140, 248, 0.12),
+    rgba(236, 72, 153, 0.1)
+  );
+  border: 1px solid rgba(129, 140, 248, 0.28);
+  color: var(--slate-700);
+  align-items: center;
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.08);
+}
+
+.shop-recommendation__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: rgba(99, 102, 241, 0.16);
+  color: #4338ca;
+  font-size: 1.2rem;
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.18);
+}
+
+.shop-recommendation strong {
+  display: block;
+  font-size: 1rem;
+  color: var(--slate-900);
+  margin-bottom: 4px;
+}
+
+.shop-recommendation p {
+  margin: 0;
+  color: var(--slate-500);
+  font-size: 0.92rem;
+}
+
 .shop-controls__top {
   display: flex;
   flex-wrap: wrap;
@@ -634,6 +677,16 @@ body.shop-page {
 
   .filter-pills {
     width: 100%;
+  }
+
+  .shop-recommendation {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .shop-recommendation__icon {
+    width: 40px;
+    height: 40px;
   }
 
   .spotlights-grid {

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -63,6 +63,7 @@ function kidstore_logout(): void
 {
     unset($_SESSION['user']);
     unset($_SESSION['admin_id'], $_SESSION['admin_name']);
+    unset($_SESSION['cart']);
 
     // Regenerate after logout to invalidate the previous identifier.
     if (session_status() === PHP_SESSION_ACTIVE) {


### PR DESCRIPTION
## Summary
- expand catalog search to tokenize queries, match category names, and expose a search context payload so the shop and API can fall back to curated recommendations
- introduce a recommendation banner, updated results messaging, and responsive styling so shoppers see guided picks when no exact matches are found
- allow full-cart clears without a product id and clear carts on logout for both storefront and admin sessions by reusing the shared logout helper

## Testing
- php -l includes/functions.php
- php -l frontend/pages/shop.php
- php -l frontend/actions/update_cart.php
- php -l frontend/actions/search_products.php
- php -l includes/auth.php
- php -l backend/bootstrap.php
- php -l backend/includes/admin_auth.php

------
https://chatgpt.com/codex/tasks/task_e_68da36013fd08324ac3fbf7dd8c3d6c9