### PR TITLE
Enhance admin dashboard experience

### DIFF
--- a/backend/assets/admin.css
+++ b/backend/assets/admin.css
@@ -184,3 +184,265 @@ a {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
+
+
+.page-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 18px;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.page-toolbar .button {
+    padding: 8px 14px;
+}
+
+.order-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    font-weight: 600;
+}
+
+.order-status,
+.tag.status-pending,
+.tag.status-processing,
+.tag.status-shipped,
+.tag.status-delivered,
+.tag.status-cancelled {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    background: rgba(59, 130, 246, 0.12);
+    color: #1d4ed8;
+}
+
+.order-status.status-pending,
+.tag.status-pending { background: rgba(250, 204, 21, 0.2); color: #ca8a04; }
+.order-status.status-processing,
+.tag.status-processing { background: rgba(59, 130, 246, 0.18); color: #2563eb; }
+.order-status.status-shipped,
+.tag.status-shipped { background: rgba(14, 165, 233, 0.18); color: #0ea5e9; }
+.order-status.status-delivered,
+.tag.status-delivered { background: rgba(34, 197, 94, 0.18); color: #15803d; }
+.order-status.status-cancelled,
+.tag.status-cancelled { background: rgba(248, 113, 113, 0.18); color: #b91c1c; }
+
+.order-id {
+    color: #6b7280;
+    font-size: 0.9rem;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+}
+
+.card-header h3 {
+    margin: 0;
+}
+
+.card-subtitle {
+    margin: 4px 0 0;
+    color: #6b7280;
+    font-size: 0.9rem;
+}
+
+.card-actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.order-columns {
+    display: grid;
+    gap: 18px;
+    margin: 24px 0;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.order-panel {
+    background: #f8fafc;
+    padding: 16px;
+    border-radius: 12px;
+}
+
+.form-inline {
+    margin-bottom: 24px;
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.input-control {
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid #d1d5db;
+    font-size: 0.95rem;
+}
+
+.metric-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    margin-bottom: 24px;
+}
+
+.metric-card {
+    background: #111827;
+    color: #f9fafb;
+    border-radius: 16px;
+    padding: 20px;
+    box-shadow: 0 10px 30px rgba(17, 24, 39, 0.25);
+    display: grid;
+    gap: 6px;
+}
+
+.metric-label {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.75;
+}
+
+.metric-value {
+    font-size: 1.8rem;
+    font-weight: 700;
+}
+
+.metric-sub {
+    font-size: 0.9rem;
+    opacity: 0.8;
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 24px;
+    margin-bottom: 24px;
+}
+
+.dashboard-column {
+    display: grid;
+    gap: 24px;
+}
+
+.status-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+}
+
+.status-card {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    background: #f8fafc;
+    border-radius: 12px;
+    padding: 14px;
+}
+
+.status-card strong {
+    display: block;
+    font-size: 0.95rem;
+}
+
+.status-card span {
+    font-size: 0.85rem;
+    color: #6b7280;
+}
+
+.status-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 999px;
+    background: #2563eb;
+}
+
+.status-dot.status-pending { background: #ca8a04; }
+.status-dot.status-processing { background: #2563eb; }
+.status-dot.status-shipped { background: #0ea5e9; }
+.status-dot.status-delivered { background: #22c55e; }
+.status-dot.status-cancelled { background: #ef4444; }
+
+.quick-actions {
+    display: grid;
+    gap: 12px;
+}
+
+.insight-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 10px;
+}
+
+.insight-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: #f8fafc;
+    padding: 12px 16px;
+    border-radius: 10px;
+    font-weight: 600;
+}
+
+.insight-list li span {
+    color: #6b7280;
+    font-weight: 500;
+}
+
+.empty-state {
+    display: grid;
+    justify-items: center;
+    gap: 8px;
+    padding: 40px 16px;
+    color: #6b7280;
+}
+
+.empty-state i {
+    font-size: 32px;
+    color: #9ca3af;
+}
+
+.dashboard-columns {
+    display: grid;
+    gap: 24px;
+    margin-bottom: 24px;
+}
+
+@media (min-width: 900px) {
+    .dashboard-columns {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+
+.button.button-compact {
+    padding: 6px 12px;
+    font-size: 0.85rem;
+}
+
+.tag.status-active {
+    background: rgba(34, 197, 94, 0.18);
+    color: #15803d;
+}
+
+.tag.status-inactive {
+    background: rgba(148, 163, 184, 0.3);
+    color: #475569;
+}

--- a/backend/assets/admin.js
+++ b/backend/assets/admin.js
@@ -16,4 +16,53 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     });
+
+    const salesCanvas = document.getElementById('salesChart');
+    if (salesCanvas) {
+        const payload = salesCanvas.getAttribute('data-sales-chart');
+        if (payload) {
+            try {
+                const data = JSON.parse(payload);
+                if (window.Chart && Array.isArray(data.labels) && Array.isArray(data.totals)) {
+                    new Chart(salesCanvas.getContext('2d'), {
+                        type: 'line',
+                        data: {
+                            labels: data.labels,
+                            datasets: [{
+                                label: 'Sales',
+                                data: data.totals,
+                                tension: 0.35,
+                                borderColor: '#6366f1',
+                                backgroundColor: 'rgba(99, 102, 241, 0.15)',
+                                fill: true,
+                                pointRadius: 4,
+                                pointBackgroundColor: '#4f46e5',
+                            }],
+                        },
+                        options: {
+                            responsive: true,
+                            plugins: {
+                                legend: { display: false },
+                                tooltip: {
+                                    callbacks: {
+                                        label: ctx => `$${ctx.parsed.y.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+                                    },
+                                },
+                            },
+                            scales: {
+                                y: {
+                                    beginAtZero: true,
+                                    ticks: {
+                                        callback: value => `$${Number(value).toLocaleString()}`,
+                                    },
+                                },
+                            },
+                        },
+                    });
+                }
+            } catch (error) {
+                console.error('Failed to render sales chart', error);
+            }
+        }
+    }
 });

--- a/backend/pages/categories.php
+++ b/backend/pages/categories.php
@@ -12,15 +12,26 @@ $prefix = KIDSTORE_ADMIN_URL_PREFIX;
 
 $status = $_GET['status'] ?? 'all';
 $status = in_array($status, ['all', 'active', 'inactive'], true) ? $status : 'all';
+$search = trim((string)($_GET['q'] ?? ''));
 
 $categories = kidstore_admin_fetch_all_categories(true);
+$activeCount = count(array_filter($categories, static fn (array $category): bool => !empty($category['is_active'])));
+$overview = [
+    'total' => count($categories),
+    'active' => $activeCount,
+    'inactive' => count($categories) - $activeCount,
+];
+
 if ($status === 'active') {
-    $categories = array_values(array_filter($categories, static function (array $category): bool {
-        return !empty($category['is_active']);
-    }));
+    $categories = array_values(array_filter($categories, static fn (array $category): bool => !empty($category['is_active'])));
 } elseif ($status === 'inactive') {
-    $categories = array_values(array_filter($categories, static function (array $category): bool {
-        return empty($category['is_active']);
+    $categories = array_values(array_filter($categories, static fn (array $category): bool => empty($category['is_active'])));
+}
+
+if ($search !== '') {
+    $categories = array_values(array_filter($categories, static function (array $category) use ($search): bool {
+        $haystack = strtolower(($category['category_name'] ?? '') . ' ' . ($category['description'] ?? ''));
+        return strpos($haystack, strtolower($search)) !== false;
     }));
 }
 
@@ -47,22 +58,42 @@ include __DIR__ . '/../includes/header.php';
 <?php endif; ?>
 
 <div class="admin-card">
-    <div class="admin-header" style="margin-bottom:16px;">
-        <h3>All Categories</h3>
-        <div style="display:flex;gap:12px;align-items:center;">
-            <form method="get" style="display:flex;gap:10px;align-items:center;">
-                <select name="status" style="padding:8px 12px;border-radius:10px;border:1px solid #d1d5db;">
-                    <option value="all" <?= $status === 'all' ? 'selected' : '' ?>>All</option>
-                    <option value="active" <?= $status === 'active' ? 'selected' : '' ?>>Active</option>
-                    <option value="inactive" <?= $status === 'inactive' ? 'selected' : '' ?>>Inactive</option>
-                </select>
-                <button class="button secondary" type="submit">Filter</button>
-            </form>
-            <a href="<?php echo $prefix; ?>pages/category_form.php" class="button primary">
-                <i class="fas fa-plus"></i> Add Category
-            </a>
+    <div class="card-header">
+        <div>
+            <h3>Category overview</h3>
+            <p class="card-subtitle">Manage <?= number_format($overview['total']) ?> collection<?= $overview['total'] === 1 ? '' : 's' ?></p>
         </div>
     </div>
+    <ul class="insight-list">
+        <li><span>Total categories</span><strong><?= number_format($overview['total']) ?></strong></li>
+        <li><span>Active</span><strong><?= number_format($overview['active']) ?></strong></li>
+        <li><span>Inactive</span><strong><?= number_format($overview['inactive']) ?></strong></li>
+    </ul>
+</div>
+
+<div class="admin-card">
+    <div class="card-header">
+        <div>
+            <h3>All categories</h3>
+            <p class="card-subtitle">Search and update merchandising groups</p>
+        </div>
+        <a href="<?php echo $prefix; ?>pages/category_form.php" class="button primary">
+            <i class="fas fa-plus"></i> Add category
+        </a>
+    </div>
+
+    <form method="get" class="form-inline" style="margin-bottom:16px;">
+        <input type="text" name="q" value="<?= htmlspecialchars($search) ?>" placeholder="Search name or description" class="input-control" />
+        <select name="status" class="input-control">
+            <option value="all" <?= $status === 'all' ? 'selected' : '' ?>>All</option>
+            <option value="active" <?= $status === 'active' ? 'selected' : '' ?>>Active</option>
+            <option value="inactive" <?= $status === 'inactive' ? 'selected' : '' ?>>Inactive</option>
+        </select>
+        <button class="button secondary" type="submit">Apply</button>
+        <?php if ($search !== '' || $status !== 'all'): ?>
+            <a href="<?php echo $prefix; ?>pages/categories.php" class="button secondary">Reset</a>
+        <?php endif; ?>
+    </form>
 
     <?php if ($categories): ?>
         <table class="table">
@@ -95,7 +126,7 @@ include __DIR__ . '/../includes/header.php';
                         </td>
                         <td>
                             <?php $isActive = !empty($category['is_active']); ?>
-                            <span class="tag" style="background: <?= $isActive ? 'rgba(34,197,94,0.15);color:#16a34a;' : 'rgba(248,113,113,0.15);color:#ef4444;' ?>">
+                            <span class="tag status-<?= $isActive ? 'active' : 'inactive' ?>">
                                 <?= $isActive ? 'Active' : 'Inactive' ?>
                             </span>
                         </td>
@@ -109,20 +140,20 @@ include __DIR__ . '/../includes/header.php';
                             <?php endif; ?>
                         </td>
                         <td style="display:flex;gap:10px;">
-                            <a href="category_form.php?id=<?= (int) $category['category_id'] ?>" class="button secondary" style="padding:6px 12px;">Edit</a>
+                            <a href="category_form.php?id=<?= (int) $category['category_id'] ?>" class="button secondary button-compact">Edit</a>
                             <?php if ($isActive): ?>
                                 <form method="post" action="<?php echo $prefix; ?>pages/category_status.php" data-confirm="Deactivate this category?" style="margin:0;">
                                     <input type="hidden" name="action" value="deactivate" />
                                     <input type="hidden" name="category_id" value="<?= (int) $category['category_id'] ?>" />
                                     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>" />
-                                    <button type="submit" class="button danger" style="padding:6px 12px;">Deactivate</button>
+                                    <button type="submit" class="button danger button-compact">Deactivate</button>
                                 </form>
                             <?php else: ?>
                                 <form method="post" action="<?php echo $prefix; ?>pages/category_status.php" style="margin:0;">
                                     <input type="hidden" name="action" value="activate" />
                                     <input type="hidden" name="category_id" value="<?= (int) $category['category_id'] ?>" />
                                     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>" />
-                                    <button type="submit" class="button primary" style="padding:6px 12px;">Activate</button>
+                                    <button type="submit" class="button primary button-compact">Activate</button>
                                 </form>
                             <?php endif; ?>
                         </td>
@@ -131,7 +162,10 @@ include __DIR__ . '/../includes/header.php';
             </tbody>
         </table>
     <?php else: ?>
-        <p>No categories found.</p>
+        <div class="empty-state">
+            <i class="fas fa-folder-open"></i>
+            <p>No categories match the selected filters.</p>
+        </div>
     <?php endif; ?>
 </div>
 

--- a/backend/pages/customers.php
+++ b/backend/pages/customers.php
@@ -8,17 +8,65 @@ kidstore_admin_require_login();
 
 $pageTitle = 'Customers';
 $currentSection = 'customers';
+$prefix = KIDSTORE_ADMIN_URL_PREFIX;
 
+$search = trim((string)($_GET['q'] ?? ''));
 $pdo = kidstore_get_pdo();
 $customers = $pdo->query('SELECT u.user_id, u.name, u.email, u.phone, u.created_at, COUNT(o.order_id) AS orders_count, COALESCE(SUM(o.total_price), 0) AS total_spent FROM tbl_users u LEFT JOIN tbl_orders o ON o.user_id = u.user_id WHERE u.is_admin = 0 GROUP BY u.user_id ORDER BY u.created_at DESC')->fetchAll();
+
+if ($search !== '') {
+    $customers = array_values(array_filter($customers, static function (array $customer) use ($search): bool {
+        $needle = strtolower($search);
+        return strpos(strtolower((string)($customer['name'] ?? '')), $needle) !== false
+            || strpos(strtolower((string)($customer['email'] ?? '')), $needle) !== false;
+    }));
+}
+
+$glance = kidstore_admin_customer_glance();
+$topCustomer = null;
+if ($customers) {
+    $topCustomer = $customers[0];
+    foreach ($customers as $candidate) {
+        if ((float) $candidate['total_spent'] > (float) $topCustomer['total_spent']) {
+            $topCustomer = $candidate;
+        }
+    }
+}
 
 include __DIR__ . '/../includes/header.php';
 ?>
 
 <div class="admin-card">
-    <div class="admin-header" style="margin-bottom:16px;">
-        <h3>Customers</h3>
+    <div class="card-header">
+        <div>
+            <h3>Customer insights</h3>
+            <p class="card-subtitle">Understand your audience growth</p>
+        </div>
     </div>
+    <ul class="insight-list">
+        <li><span>Total customers</span><strong><?= number_format($glance['total']) ?></strong></li>
+        <li><span>Joined last 30 days</span><strong><?= number_format($glance['new_customers']) ?></strong></li>
+        <li><span>Lifetime revenue</span><strong>$<?= number_format((float) $glance['gross_revenue'], 2) ?></strong></li>
+        <?php if ($topCustomer): ?>
+            <li><span>Top spender</span><strong><?= htmlspecialchars($topCustomer['name'] ?? 'Unknown') ?> ($<?= number_format((float) $topCustomer['total_spent'], 2) ?>)</strong></li>
+        <?php endif; ?>
+    </ul>
+</div>
+
+<div class="admin-card">
+    <div class="card-header">
+        <div>
+            <h3>Customers</h3>
+            <p class="card-subtitle">View purchase history and contact info</p>
+        </div>
+    </div>
+    <form method="get" class="form-inline" style="margin-bottom:16px;">
+        <input type="text" name="q" value="<?= htmlspecialchars($search) ?>" placeholder="Search name or email" class="input-control" />
+        <button class="button secondary" type="submit">Search</button>
+        <?php if ($search !== ''): ?>
+            <a href="<?php echo $prefix; ?>pages/customers.php" class="button secondary">Reset</a>
+        <?php endif; ?>
+    </form>
     <?php if ($customers): ?>
         <table class="table">
             <thead>
@@ -27,7 +75,7 @@ include __DIR__ . '/../includes/header.php';
                     <th>Email</th>
                     <th>Phone</th>
                     <th>Orders</th>
-                    <th>Total Spent</th>
+                    <th>Total spent</th>
                     <th>Joined</th>
                 </tr>
             </thead>
@@ -36,7 +84,7 @@ include __DIR__ . '/../includes/header.php';
                     <tr>
                         <td><?= htmlspecialchars($customer['name']) ?></td>
                         <td><?= htmlspecialchars($customer['email']) ?></td>
-                        <td><?= htmlspecialchars($customer['phone'] ?? '?') ?></td>
+                        <td><?= htmlspecialchars($customer['phone'] ?? '—') ?></td>
                         <td><?= (int) $customer['orders_count'] ?></td>
                         <td>$<?= number_format((float) $customer['total_spent'], 2) ?></td>
                         <td><?= date('M j, Y', strtotime((string) $customer['created_at'])) ?></td>
@@ -45,7 +93,10 @@ include __DIR__ . '/../includes/header.php';
             </tbody>
         </table>
     <?php else: ?>
-        <p>No customers yet.</p>
+        <div class="empty-state">
+            <i class="fas fa-user"></i>
+            <p>No customers match the search criteria.</p>
+        </div>
     <?php endif; ?>
 </div>
 

--- a/backend/pages/dashboard.php
+++ b/backend/pages/dashboard.php
@@ -9,7 +9,18 @@ kidstore_admin_require_login();
 $pageTitle = 'Dashboard';
 $currentSection = 'dashboard';
 $metrics = kidstore_admin_dashboard_metrics();
-$recentOrders = kidstore_admin_fetch_orders(['limit' => 5]);
+$orderBreakdown = kidstore_admin_order_status_breakdown();
+$productOverview = kidstore_admin_product_overview();
+$salesSeries = kidstore_admin_monthly_sales(6);
+$salesChartData = [
+    'labels' => array_map(static fn (array $row): string => $row['label'], $salesSeries),
+    'totals' => array_map(static fn (array $row): float => round($row['total'], 2), $salesSeries),
+];
+$salesChartJson = htmlspecialchars(json_encode($salesChartData, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT), ENT_QUOTES, 'UTF-8');
+
+$recentOrders = kidstore_admin_fetch_orders([
+    'limit' => 5,
+]);
 $recentProducts = kidstore_admin_fetch_products([
     'limit' => 5,
     'sort' => 'newest',
@@ -18,87 +29,167 @@ $recentProducts = kidstore_admin_fetch_products([
 include __DIR__ . '/../includes/header.php';
 ?>
 
-<div class="stats-grid">
-    <div class="stat-card">
-        <h3>Total Orders</h3>
-        <strong><?= number_format($metrics['order_count']) ?></strong>
+<div class="metric-grid">
+    <div class="metric-card">
+        <span class="metric-label">Total Sales</span>
+        <span class="metric-value">$<?= number_format($metrics['total_sales'], 2) ?></span>
+        <span class="metric-sub">Today: $<?= number_format($metrics['today_sales'], 2) ?></span>
     </div>
-    <div class="stat-card">
-        <h3>Total Sales</h3>
-        <strong>$<?= number_format($metrics['total_sales'], 2) ?></strong>
+    <div class="metric-card">
+        <span class="metric-label">Orders</span>
+        <span class="metric-value"><?= number_format($metrics['order_count']) ?></span>
+        <span class="metric-sub">Pending: <?= number_format($metrics['pending_orders']) ?></span>
     </div>
-    <div class="stat-card">
-        <h3>Products</h3>
-        <strong><?= number_format($metrics['product_count']) ?></strong>
+    <div class="metric-card">
+        <span class="metric-label">Customers</span>
+        <span class="metric-value"><?= number_format($metrics['customer_count']) ?></span>
+        <span class="metric-sub">New this month: <?= number_format($metrics['recent_customers']) ?></span>
     </div>
-    <div class="stat-card">
-        <h3>Items in Stock</h3>
-        <strong><?= number_format($metrics['items_in_stock']) ?></strong>
+    <div class="metric-card">
+        <span class="metric-label">Inventory</span>
+        <span class="metric-value"><?= number_format($metrics['items_in_stock']) ?></span>
+        <span class="metric-sub">Low stock: <?= number_format($metrics['low_stock']) ?></span>
     </div>
 </div>
 
-<div class="admin-card">
-    <div class="admin-header" style="margin-bottom:16px;">
-        <h3>Recent Orders</h3>
-        <a href="<?php echo $prefix; ?>pages/orders.php" class="button secondary">View all</a>
-    </div>
-    <?php if ($recentOrders): ?>
-        <table class="table">
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Customer</th>
-                    <th>Status</th>
-                    <th>Total</th>
-                    <th>Placed</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ($recentOrders as $order): ?>
-                    <tr>
-                        <td><a href="<?php echo $prefix; ?>pages/order_view.php?id=<?= (int) $order['order_id'] ?>">#<?= str_pad((string) $order['order_id'], 5, '0', STR_PAD_LEFT) ?></a></td>
-                        <td><?= htmlspecialchars($order['customer_name']) ?></td>
-                        <td><span class="tag"><?= htmlspecialchars(ucfirst($order['status'])) ?></span></td>
-                        <td>$<?= number_format((float) $order['total_price'], 2) ?></td>
-                        <td><?= date('M j, Y', strtotime((string) $order['created_at'])) ?></td>
-                    </tr>
+<div class="dashboard-grid">
+    <section class="dashboard-column">
+        <div class="admin-card">
+            <div class="card-header">
+                <div>
+                    <h3>Sales trend</h3>
+                    <p class="card-subtitle">Revenue for the past 6 months</p>
+                </div>
+            </div>
+            <canvas id="salesChart" data-sales-chart="<?= $salesChartJson ?>"></canvas>
+        </div>
+
+        <div class="admin-card">
+            <div class="card-header">
+                <div>
+                    <h3>Order pipeline</h3>
+                    <p class="card-subtitle">Monitor fulfillment progress</p>
+                </div>
+                <a href="<?php echo $prefix; ?>pages/orders.php" class="button secondary">View orders</a>
+            </div>
+            <div class="status-grid">
+                <?php foreach ($orderBreakdown as $status => $total): ?>
+                    <div class="status-card">
+                        <span class="status-dot status-<?= htmlspecialchars($status) ?>"></span>
+                        <div>
+                            <strong><?= htmlspecialchars(ucfirst($status)) ?></strong>
+                            <span><?= number_format($total) ?> orders</span>
+                        </div>
+                    </div>
                 <?php endforeach; ?>
-            </tbody>
-        </table>
-    <?php else: ?>
-        <p>No orders yet.</p>
-    <?php endif; ?>
+            </div>
+        </div>
+    </section>
+
+    <section class="dashboard-column">
+        <div class="admin-card">
+            <div class="card-header">
+                <div>
+                    <h3>Quick actions</h3>
+                    <p class="card-subtitle">Jump back into store management</p>
+                </div>
+            </div>
+            <div class="quick-actions">
+                <a href="<?php echo $prefix; ?>pages/product_form.php" class="button primary"><i class="fas fa-plus"></i> Add product</a>
+                <a href="<?php echo $prefix; ?>pages/categories.php" class="button secondary"><i class="fas fa-tags"></i> Manage categories</a>
+                <a href="<?php echo $prefix; ?>pages/orders.php" class="button secondary"><i class="fas fa-receipt"></i> Review orders</a>
+                <a href="<?php echo $prefix; ?>pages/customers.php" class="button secondary"><i class="fas fa-users"></i> View customers</a>
+            </div>
+        </div>
+
+        <div class="admin-card">
+            <div class="card-header">
+                <div>
+                    <h3>Inventory snapshot</h3>
+                    <p class="card-subtitle">Keep an eye on product availability</p>
+                </div>
+            </div>
+            <ul class="insight-list">
+                <li><span>Total products</span><strong><?= number_format($productOverview['total']) ?></strong></li>
+                <li><span>Active listings</span><strong><?= number_format($productOverview['active']) ?></strong></li>
+                <li><span>Inactive listings</span><strong><?= number_format($productOverview['inactive']) ?></strong></li>
+                <li><span>Low stock alerts</span><strong><?= number_format($productOverview['low_stock']) ?></strong></li>
+                <li><span>Out of stock</span><strong><?= number_format($productOverview['out_of_stock']) ?></strong></li>
+            </ul>
+        </div>
+    </section>
 </div>
 
-<div class="admin-card">
-    <div class="admin-header" style="margin-bottom:16px;">
-        <h3>Recently Added Products</h3>
-        <a href="<?php echo $prefix; ?>pages/products.php" class="button secondary">Manage</a>
-    </div>
-    <?php if ($recentProducts): ?>
-        <table class="table">
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Price</th>
-                    <th>Stock</th>
-                    <th>Status</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ($recentProducts as $product): ?>
+<div class="dashboard-columns">
+    <div class="admin-card">
+        <div class="card-header">
+            <h3>Recent orders</h3>
+            <a href="<?php echo $prefix; ?>pages/orders.php" class="button secondary">View all</a>
+        </div>
+        <?php if ($recentOrders): ?>
+            <table class="table">
+                <thead>
                     <tr>
-                        <td><?= htmlspecialchars($product['product_name']) ?></td>
-                        <td>$<?= number_format((float) $product['price'], 2) ?></td>
-                        <td><?= (int) $product['stock_quantity'] ?></td>
-                        <td><?= htmlspecialchars(ucfirst($product['status'])) ?></td>
+                        <th>#</th>
+                        <th>Customer</th>
+                        <th>Status</th>
+                        <th>Total</th>
+                        <th>Placed</th>
                     </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
-    <?php else: ?>
-        <p>No products available.</p>
-    <?php endif; ?>
+                </thead>
+                <tbody>
+                    <?php foreach ($recentOrders as $order): ?>
+                        <tr>
+                            <td><a href="<?php echo $prefix; ?>pages/order_view.php?id=<?= (int) $order['order_id'] ?>">#<?= str_pad((string) $order['order_id'], 5, '0', STR_PAD_LEFT) ?></a></td>
+                            <td><?= htmlspecialchars($order['customer_name']) ?></td>
+                            <td><span class="tag status-<?= htmlspecialchars($order['status']) ?>"><?= htmlspecialchars(ucfirst($order['status'])) ?></span></td>
+                            <td>$<?= number_format((float) $order['total_price'], 2) ?></td>
+                            <td><?= date('M j, Y', strtotime((string) $order['created_at'])) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else: ?>
+            <div class="empty-state">
+                <i class="fas fa-receipt"></i>
+                <p>No orders yet. Share your store to start selling!</p>
+            </div>
+        <?php endif; ?>
+    </div>
+
+    <div class="admin-card">
+        <div class="card-header">
+            <h3>Recently added products</h3>
+            <a href="<?php echo $prefix; ?>pages/products.php" class="button secondary">Manage</a>
+        </div>
+        <?php if ($recentProducts): ?>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Price</th>
+                        <th>Stock</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($recentProducts as $product): ?>
+                        <tr>
+                            <td><?= htmlspecialchars($product['product_name']) ?></td>
+                            <td>$<?= number_format((float) $product['price'], 2) ?></td>
+                            <td><?= (int) $product['stock_quantity'] ?></td>
+                            <td><span class="tag status-<?= htmlspecialchars($product['status']) ?>"><?= htmlspecialchars(ucfirst($product['status'])) ?></span></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php else: ?>
+            <div class="empty-state">
+                <i class="fas fa-box"></i>
+                <p>No products available. Create your first listing.</p>
+            </div>
+        <?php endif; ?>
+    </div>
 </div>
 
 <?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/backend/pages/order_view.php
+++ b/backend/pages/order_view.php
@@ -55,6 +55,16 @@ $csrfToken = kidstore_csrf_token();
 include __DIR__ . '/../includes/header.php';
 ?>
 
+<div class="page-toolbar">
+    <a class="button secondary" href="<?php echo $prefix; ?>pages/orders.php" onclick="if (window.history.length > 1) { window.history.back(); return false; } return true;">
+        <i class="fas fa-arrow-left"></i> Back to Orders
+    </a>
+    <div class="order-meta">
+        <span class="order-status status-<?= htmlspecialchars($order['status']) ?>">Status: <?= htmlspecialchars(ucfirst($order['status'])) ?></span>
+        <span class="order-id">Order #<?= str_pad((string) $orderId, 5, '0', STR_PAD_LEFT) ?></span>
+    </div>
+</div>
+
 <?php if (!empty($flashMessage)): ?>
     <div class="admin-card" style="background:#dcfce7;color:#166534;">
         <?= htmlspecialchars($flashMessage) ?>
@@ -62,17 +72,29 @@ include __DIR__ . '/../includes/header.php';
 <?php endif; ?>
 
 <div class="admin-card">
-    <h3>Order Details</h3>
-    <p>Placed on <?= date('F j, Y 	 g:i A', strtotime((string) $order['created_at'])) ?></p>
+    <div class="card-header">
+        <div>
+            <h3>Order Details</h3>
+            <p>Placed on <?= date('F j, Y g:i A', strtotime((string) $order['created_at'])) ?></p>
+        </div>
+        <div class="card-actions">
+            <a class="button secondary" href="mailto:<?= htmlspecialchars($order['customer_email']) ?>">
+                <i class="fas fa-envelope"></i> Email customer
+            </a>
+            <button class="button secondary" type="button" onclick="window.print()">
+                <i class="fas fa-print"></i> Print
+            </button>
+        </div>
+    </div>
 
-    <div style="display:grid;gap:18px;margin:24px 0;grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));">
-        <div style="background:#f8fafc;padding:16px;border-radius:12px;">
+    <div class="order-columns">
+        <div class="order-panel">
             <h4>Customer</h4>
             <p><?= htmlspecialchars($order['customer_name']) ?><br />
                <?= htmlspecialchars($order['customer_email']) ?><br />
                <?= htmlspecialchars($order['customer_phone'] ?? 'N/A') ?></p>
         </div>
-        <div style="background:#f8fafc;padding:16px;border-radius:12px;">
+        <div class="order-panel">
             <h4>Payment</h4>
             <?php if (!empty($order['payment'])): ?>
                 <p>Method: <?= htmlspecialchars($order['payment']['payment_method']) ?><br />
@@ -82,7 +104,7 @@ include __DIR__ . '/../includes/header.php';
                 <p>No payment record.</p>
             <?php endif; ?>
         </div>
-        <div style="background:#f8fafc;padding:16px;border-radius:12px;">
+        <div class="order-panel">
             <h4>Shipping</h4>
             <?php if ($shipping): ?>
                 <p><?= htmlspecialchars($shipping['recipient_name']) ?><br />
@@ -96,10 +118,10 @@ include __DIR__ . '/../includes/header.php';
         </div>
     </div>
 
-    <form method="post" style="margin-bottom:24px;display:flex;gap:12px;align-items:center;">
+    <form method="post" class="form-inline">
         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>" />
         <label for="status">Update status:</label>
-        <select id="status" name="status" style="padding:8px 12px;border-radius:10px;border:1px solid #d1d5db;">
+        <select id="status" name="status" class="input-control">
             <?php foreach (['pending','processing','shipped','delivered','cancelled'] as $option): ?>
                 <option value="<?= $option ?>" <?= $order['status'] === $option ? 'selected' : '' ?>><?= ucfirst($option) ?></option>
             <?php endforeach; ?>

--- a/backend/pages/products.php
+++ b/backend/pages/products.php
@@ -10,14 +10,28 @@ $pageTitle = 'Products';
 $currentSection = 'products';
 
 $status = $_GET['status'] ?? '';
+$search = trim((string)($_GET['q'] ?? ''));
+$availability = $_GET['availability'] ?? '';
+$sort = $_GET['sort'] ?? 'name';
+$validSorts = ['name', 'newest', 'price_asc', 'price_desc'];
+
 $filters = [
-    'sort' => 'name',
+    'sort' => in_array($sort, $validSorts, true) ? $sort : 'name',
     'activeOnly' => false,
 ];
+
 if ($status !== '') {
     $filters['status'] = $status;
 }
+if ($search !== '') {
+    $filters['search'] = $search;
+}
+if (in_array($availability, ['in_stock', 'out_of_stock'], true)) {
+    $filters['availability'] = $availability;
+}
+
 $products = kidstore_admin_fetch_products($filters);
+$productOverview = kidstore_admin_product_overview();
 $flash = $_SESSION['admin_flash'] ?? null;
 unset($_SESSION['admin_flash']);
 $csrfToken = kidstore_csrf_token();
@@ -32,20 +46,54 @@ include __DIR__ . '/../includes/header.php';
 <?php endif; ?>
 
 <div class="admin-card">
-    <div class="admin-header" style="margin-bottom:16px;">
-        <h3>All Products</h3>
-        <div style="display:flex;gap:12px;align-items:center;">
-            <form method="get" style="display:flex;gap:10px;align-items:center;">
-                <select name="status" style="padding:8px 12px;border-radius:10px;border:1px solid #d1d5db;">
-                    <option value="">All Statuses</option>
-                    <option value="active" <?= $status === 'active' ? 'selected' : '' ?>>Active</option>
-                    <option value="inactive" <?= $status === 'inactive' ? 'selected' : '' ?>>Inactive</option>
-                </select>
-                <button class="button secondary" type="submit">Filter</button>
-            </form>
-            <a href="<?php echo $prefix; ?>pages/product_form.php" class="button primary"><i class="fas fa-plus"></i> Add Product</a>
+    <div class="card-header">
+        <div>
+            <h3>Inventory overview</h3>
+            <p class="card-subtitle">Snapshot of your product catalog</p>
         </div>
     </div>
+    <ul class="insight-list">
+        <li><span>Total products</span><strong><?= number_format($productOverview['total']) ?></strong></li>
+        <li><span>Active</span><strong><?= number_format($productOverview['active']) ?></strong></li>
+        <li><span>Inactive</span><strong><?= number_format($productOverview['inactive']) ?></strong></li>
+        <li><span>Low stock</span><strong><?= number_format($productOverview['low_stock']) ?></strong></li>
+        <li><span>Out of stock</span><strong><?= number_format($productOverview['out_of_stock']) ?></strong></li>
+    </ul>
+</div>
+
+<div class="admin-card">
+    <div class="card-header">
+        <div>
+            <h3>All products</h3>
+            <p class="card-subtitle">Search, filter, and manage listings</p>
+        </div>
+        <a href="<?php echo $prefix; ?>pages/product_form.php" class="button primary"><i class="fas fa-plus"></i> Add product</a>
+    </div>
+
+    <form method="get" class="form-inline" style="margin-bottom:16px;">
+        <input type="text" name="q" value="<?= htmlspecialchars($search) ?>" placeholder="Search by name or category" class="input-control" />
+        <select name="status" class="input-control">
+            <option value="">All statuses</option>
+            <option value="active" <?= $status === 'active' ? 'selected' : '' ?>>Active</option>
+            <option value="inactive" <?= $status === 'inactive' ? 'selected' : '' ?>>Inactive</option>
+        </select>
+        <select name="availability" class="input-control">
+            <option value="">Any availability</option>
+            <option value="in_stock" <?= $availability === 'in_stock' ? 'selected' : '' ?>>In stock</option>
+            <option value="out_of_stock" <?= $availability === 'out_of_stock' ? 'selected' : '' ?>>Out of stock</option>
+        </select>
+        <select name="sort" class="input-control">
+            <option value="name" <?= $sort === 'name' ? 'selected' : '' ?>>Alphabetical</option>
+            <option value="newest" <?= $sort === 'newest' ? 'selected' : '' ?>>Newest</option>
+            <option value="price_asc" <?= $sort === 'price_asc' ? 'selected' : '' ?>>Price: Low to high</option>
+            <option value="price_desc" <?= $sort === 'price_desc' ? 'selected' : '' ?>>Price: High to low</option>
+        </select>
+        <button class="button secondary" type="submit">Apply</button>
+        <?php if ($search !== '' || $status !== '' || $availability !== '' || $sort !== 'name'): ?>
+            <a href="<?php echo $prefix; ?>pages/products.php" class="button secondary">Reset</a>
+        <?php endif; ?>
+    </form>
+
     <?php if ($products): ?>
         <table class="table">
             <thead>
@@ -66,16 +114,16 @@ include __DIR__ . '/../includes/header.php';
                         <td>$<?= number_format((float) $product['price'], 2) ?></td>
                         <td><?= (int) $product['stock_quantity'] ?></td>
                         <td>
-                            <span class="tag" style="background: <?= $product['status'] === 'active' ? 'rgba(34,197,94,0.15);color:#16a34a;' : 'rgba(248,113,113,0.15);color:#ef4444;' ?>">
+                            <span class="tag status-<?= htmlspecialchars($product['status']) ?>">
                                 <?= htmlspecialchars(ucfirst($product['status'])) ?>
                             </span>
                         </td>
                         <td style="display:flex;gap:10px;">
-                            <a href="product_form.php?id=<?= (int) $product['product_id'] ?>" class="button secondary" style="padding:6px 12px;">Edit</a>
+                            <a href="product_form.php?id=<?= (int) $product['product_id'] ?>" class="button secondary button-compact">Edit</a>
                             <form method="post" action="<?php echo $prefix; ?>pages/product_delete.php" data-confirm="Archive this product?" style="margin:0;">
                                 <input type="hidden" name="product_id" value="<?= (int) $product['product_id'] ?>" />
                                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>" />
-                                <button type="submit" class="button danger" style="padding:6px 12px;">Delete</button>
+                                <button type="submit" class="button danger button-compact">Delete</button>
                             </form>
                         </td>
                     </tr>
@@ -83,11 +131,11 @@ include __DIR__ . '/../includes/header.php';
             </tbody>
         </table>
     <?php else: ?>
-        <p>No products found.</p>
+        <div class="empty-state">
+            <i class="fas fa-box"></i>
+            <p>No products match the selected filters.</p>
+        </div>
     <?php endif; ?>
 </div>
 
 <?php include __DIR__ . '/../includes/footer.php'; ?>
-
-
-


### PR DESCRIPTION
## Summary
- extend admin helpers to deliver richer dashboard metrics, sales trends, and inventory/customer insights
- refresh dashboard, catalog, order, category, customer, and order detail pages with quick actions, filtering, and improved layouts for demos
- update shared admin styles and scripts to support new components, status chips, and chart rendering

## Testing
- php -l backend/pages/dashboard.php
- php -l backend/pages/orders.php
- php -l backend/pages/products.php
- php -l backend/pages/categories.php
- php -l backend/pages/customers.php
- php -l backend/pages/order_view.php
- php -l includes/admin.php

------
https://chatgpt.com/codex/tasks/task_e_68da48a775a883249ff8e9230594ca59