### PR TITLE
Add customer service informational pages for footer links

### DIFF
--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -859,6 +859,192 @@ h2 {
   margin-bottom: 20px;
 }
 
+/* Informational Pages */
+.page-hero {
+  background-color: #f9f9f9;
+  padding: 80px 20px 40px;
+  text-align: center;
+}
+
+.page-hero h1 {
+  font-size: 2.8rem;
+  margin-bottom: 10px;
+}
+
+.page-hero p {
+  font-size: 1.1rem;
+  color: #666;
+}
+
+.info-section {
+  padding: 60px 20px;
+}
+
+.info-section.accent {
+  background-color: #fff4f4;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 30px;
+}
+
+.info-card {
+  background-color: #fff;
+  padding: 30px;
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+}
+
+.info-card h2 {
+  font-size: 1.6rem;
+  color: #333;
+  margin-bottom: 15px;
+}
+
+.info-card p,
+.info-card li {
+  color: #555;
+  line-height: 1.7;
+}
+
+.info-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.tips-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 30px;
+  margin-top: 30px;
+}
+
+.tip-item {
+  background-color: #fff;
+  padding: 30px;
+  border-radius: 10px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.05);
+  text-align: center;
+}
+
+.tip-item i {
+  font-size: 2.4rem;
+  color: #ff6b6b;
+  margin-bottom: 15px;
+}
+
+.tip-item h3 {
+  font-size: 1.4rem;
+  margin-bottom: 10px;
+  color: #333;
+}
+
+.cta-section {
+  background-color: #ff6b6b;
+  color: #fff;
+  text-align: center;
+  padding: 70px 20px;
+}
+
+.cta-section p {
+  max-width: 540px;
+  margin: 0 auto 20px;
+  line-height: 1.7;
+}
+
+.cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 15px;
+}
+
+.steps-list {
+  counter-reset: step;
+  list-style: none;
+  padding: 0;
+  margin: 30px 0;
+}
+
+.steps-list li {
+  counter-increment: step;
+  margin-bottom: 15px;
+  padding-left: 45px;
+  position: relative;
+  line-height: 1.7;
+  color: #555;
+}
+
+.steps-list li::before {
+  content: counter(step);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background-color: #ff6b6b;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.note {
+  font-size: 0.95rem;
+  color: #777;
+  margin-top: 20px;
+}
+
+.bullet-list {
+  list-style: disc;
+  margin: 20px 0 0 20px;
+  color: #555;
+  line-height: 1.7;
+}
+
+.faq-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 30px;
+}
+
+.faq-item {
+  background-color: #fff;
+  padding: 30px;
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+}
+
+.faq-item h2 {
+  font-size: 1.5rem;
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.faq-item p {
+  color: #555;
+  line-height: 1.7;
+}
+
+@media (max-width: 768px) {
+  .page-hero {
+    padding: 60px 15px 30px;
+  }
+
+  .page-hero h1 {
+    font-size: 2.2rem;
+  }
+
+  .cta-section {
+    padding: 60px 15px;
+  }
+}
+
 .form-group label {
   display: block;
   font-weight: bold;

--- a/frontend/pages/faq.php
+++ b/frontend/pages/faq.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../includes/bootstrap.php';
+
+$prefix = KIDSTORE_FRONT_URL_PREFIX;
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Frequently Asked Questions - Little Stars</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="<?php echo $prefix; ?>assets/styles.css" rel="stylesheet">
+</head>
+<body>
+    <?php include __DIR__ . '/../partials/header.php'; ?>
+
+    <main>
+        <section class="page-hero">
+            <div class="container">
+                <h1>Frequently Asked Questions</h1>
+                <p>Answers to the questions parents ask us most.</p>
+            </div>
+        </section>
+
+        <section class="info-section">
+            <div class="container">
+                <div class="faq-grid">
+                    <div class="faq-item">
+                        <h2>Do you restock sold-out items?</h2>
+                        <p>Yes! Our design team refreshes best sellers regularly. Sign up for restock alerts on the product page to be the first to know.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h2>What materials do you use?</h2>
+                        <p>We prioritize soft, breathable fabrics like organic cotton and bamboo blends that are gentle on sensitive skin.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h2>Can I modify my order after placing it?</h2>
+                        <p>Orders move quickly, but contact us within 1 hour and we'll do our best to update addresses, sizes, or styles.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h2>Do you offer gift wrapping?</h2>
+                        <p>Absolutely! Choose "Gift Wrap" at checkout and we'll include a handwritten note and keepsake box.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h2>How do I earn rewards?</h2>
+                        <p>Create an account to earn Stars on every purchase. Redeem them for exclusive discounts and early access launches.</p>
+                    </div>
+                    <div class="faq-item">
+                        <h2>Are your clothes true to size?</h2>
+                        <p>Our styles are crafted to match the size guide above. When in doubt, check the fit notes on each product page.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="info-section accent">
+            <div class="container">
+                <h2>Still Curious?</h2>
+                <p>Our Little Stars stylists love chatting about upcoming collections, fit tips, and gift ideas.</p>
+                <div class="cta-actions">
+                    <a class="button ghost" href="<?php echo $prefix; ?>pages/contact.php">Contact Us</a>
+                    <a class="button solid" href="<?php echo $prefix; ?>pages/shop.php">Return to Shop</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <?php include __DIR__ . '/../partials/footer.php'; ?>
+    <button class="scroll-to-top" style="display: none;"><i class="fas fa-chevron-up"></i></button>
+
+    <script src="<?php echo $prefix; ?>assets/script.js"></script>
+</body>
+</html>

--- a/frontend/pages/returns.php
+++ b/frontend/pages/returns.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../includes/bootstrap.php';
+
+$prefix = KIDSTORE_FRONT_URL_PREFIX;
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Returns & Exchanges - Little Stars</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="<?php echo $prefix; ?>assets/styles.css" rel="stylesheet">
+</head>
+<body>
+    <?php include __DIR__ . '/../partials/header.php'; ?>
+
+    <main>
+        <section class="page-hero">
+            <div class="container">
+                <h1>Returns & Exchanges</h1>
+                <p>Happiness guaranteed. If something's not quite right, we're here to help.</p>
+            </div>
+        </section>
+
+        <section class="info-section">
+            <div class="container">
+                <div class="info-grid">
+                    <div class="info-card">
+                        <h2>Return Window</h2>
+                        <p>You have 30 days from delivery to return unworn, unwashed items with original tags attached.</p>
+                    </div>
+                    <div class="info-card">
+                        <h2>Easy Exchanges</h2>
+                        <p>Need a different size or color? Start an exchange to secure your preferred item before it sells out.</p>
+                    </div>
+                    <div class="info-card">
+                        <h2>Gift Returns</h2>
+                        <p>Returning a gift? Choose store credit and we'll keep the gift giver's secret safe.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="info-section accent">
+            <div class="container">
+                <h2>How to Start a Return</h2>
+                <ol class="steps-list">
+                    <li>Visit your order history and select the items you'd like to return.</li>
+                    <li>Choose a return or exchange and print your prepaid label.</li>
+                    <li>Drop the package at any carrier location and keep the receipt for your records.</li>
+                </ol>
+                <p class="note">Please allow 5-7 business days for returns to be processed once they reach our studio.</p>
+            </div>
+        </section>
+
+        <section class="info-section">
+            <div class="container">
+                <h2>Items Not Eligible for Return</h2>
+                <ul class="bullet-list">
+                    <li>Final sale items marked "Last Chance"</li>
+                    <li>Personalized pieces with custom embroidery</li>
+                    <li>Worn or washed garments</li>
+                    <li>Socks, tights, and hair accessories once opened</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="cta-section">
+            <div class="container">
+                <h2>Need a Hand?</h2>
+                <p>Our team loves helping you find the right fit. Reach out or head back to the shop to keep exploring.</p>
+                <div class="cta-actions">
+                    <a class="button ghost" href="<?php echo $prefix; ?>pages/contact.php">Contact Support</a>
+                    <a class="button solid" href="<?php echo $prefix; ?>pages/shop.php">Return to Shop</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <?php include __DIR__ . '/../partials/footer.php'; ?>
+    <button class="scroll-to-top" style="display: none;"><i class="fas fa-chevron-up"></i></button>
+
+    <script src="<?php echo $prefix; ?>assets/script.js"></script>
+</body>
+</html>

--- a/frontend/pages/shipping.php
+++ b/frontend/pages/shipping.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../includes/bootstrap.php';
+
+$prefix = KIDSTORE_FRONT_URL_PREFIX;
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Shipping Information - Little Stars</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="<?php echo $prefix; ?>assets/styles.css" rel="stylesheet">
+</head>
+<body>
+    <?php include __DIR__ . '/../partials/header.php'; ?>
+
+    <main>
+        <section class="page-hero">
+            <div class="container">
+                <h1>Shipping Information</h1>
+                <p>Quick, reliable delivery to bring smiles straight to your doorstep.</p>
+            </div>
+        </section>
+
+        <section class="info-section">
+            <div class="container">
+                <div class="info-grid">
+                    <div class="info-card">
+                        <h2>Delivery Options</h2>
+                        <ul>
+                            <li><strong>Standard Shipping:</strong> 4-6 business days &bull; Complimentary on orders over $75</li>
+                            <li><strong>Expedited Shipping:</strong> 2-3 business days &bull; Flat $12.95</li>
+                            <li><strong>Overnight Shipping:</strong> Next business day &bull; Calculated at checkout</li>
+                        </ul>
+                    </div>
+                    <div class="info-card">
+                        <h2>Processing Times</h2>
+                        <p>Orders placed before 1 PM ET ship the same day. Weekend orders ship Monday. Personalized pieces may add 1-2 extra days.</p>
+                    </div>
+                    <div class="info-card">
+                        <h2>International</h2>
+                        <p>We currently ship to Canada, the UK, and Australia. Duties are calculated upfront so there are no surprise fees at delivery.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="info-section accent">
+            <div class="container">
+                <h2>Tracking & Updates</h2>
+                <div class="tips-grid">
+                    <div class="tip-item">
+                        <i class="fas fa-envelope-open-text"></i>
+                        <h3>Shipping Confirmation</h3>
+                        <p>You'll receive an email with your tracking link as soon as your order leaves our studio.</p>
+                    </div>
+                    <div class="tip-item">
+                        <i class="fas fa-map-marker-alt"></i>
+                        <h3>Live Tracking</h3>
+                        <p>Follow every step of the journey and sign up for carrier text updates during checkout.</p>
+                    </div>
+                    <div class="tip-item">
+                        <i class="fas fa-headset"></i>
+                        <h3>Need Help?</h3>
+                        <p>Our care team is available 7 days a week at <a href="mailto:hello@littlestars.com">hello@littlestars.com</a>.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="cta-section">
+            <div class="container">
+                <h2>Shop New Arrivals with Confidence</h2>
+                <p>From checkout to delivery, we keep you updated every step of the way.</p>
+                <a class="button solid" href="<?php echo $prefix; ?>pages/shop.php">Return to Shop</a>
+            </div>
+        </section>
+    </main>
+
+    <?php include __DIR__ . '/../partials/footer.php'; ?>
+    <button class="scroll-to-top" style="display: none;"><i class="fas fa-chevron-up"></i></button>
+
+    <script src="<?php echo $prefix; ?>assets/script.js"></script>
+</body>
+</html>

--- a/frontend/pages/size-guide.php
+++ b/frontend/pages/size-guide.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../includes/bootstrap.php';
+
+$prefix = KIDSTORE_FRONT_URL_PREFIX;
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Size Guide - Little Stars</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="<?php echo $prefix; ?>assets/styles.css" rel="stylesheet">
+</head>
+<body>
+    <?php include __DIR__ . '/../partials/header.php'; ?>
+
+    <main>
+        <section class="page-hero">
+            <div class="container">
+                <h1>Find the Perfect Fit</h1>
+                <p>Comfortable, play-ready outfits sized with growing kids in mind.</p>
+            </div>
+        </section>
+
+        <section class="info-section">
+            <div class="container">
+                <div class="info-grid">
+                    <div class="info-card">
+                        <h2>Baby (0-24 months)</h2>
+                        <ul>
+                            <li><strong>Newborn:</strong> Up to 7 lbs &bull; 18-21 in</li>
+                            <li><strong>0-3 months:</strong> 7-12 lbs &bull; 21-24 in</li>
+                            <li><strong>3-6 months:</strong> 12-17 lbs &bull; 24-27 in</li>
+                            <li><strong>6-12 months:</strong> 17-22 lbs &bull; 27-29 in</li>
+                            <li><strong>12-24 months:</strong> 22-28 lbs &bull; 29-33 in</li>
+                        </ul>
+                    </div>
+                    <div class="info-card">
+                        <h2>Toddler (2T-5T)</h2>
+                        <ul>
+                            <li><strong>2T:</strong> 26-30 lbs &bull; 33-36 in</li>
+                            <li><strong>3T:</strong> 30-34 lbs &bull; 36-39 in</li>
+                            <li><strong>4T:</strong> 34-39 lbs &bull; 39-42 in</li>
+                            <li><strong>5T:</strong> 39-45 lbs &bull; 42-45 in</li>
+                        </ul>
+                    </div>
+                    <div class="info-card">
+                        <h2>Kids (4-12 years)</h2>
+                        <ul>
+                            <li><strong>XS (4-5):</strong> 40-46 lbs &bull; 42-46 in</li>
+                            <li><strong>S (6-7):</strong> 46-60 lbs &bull; 46-50 in</li>
+                            <li><strong>M (8-9):</strong> 60-74 lbs &bull; 50-54 in</li>
+                            <li><strong>L (10-11):</strong> 74-90 lbs &bull; 54-58 in</li>
+                            <li><strong>XL (12):</strong> 90-105 lbs &bull; 58-62 in</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="info-section accent">
+            <div class="container">
+                <h2>Fit Tips</h2>
+                <div class="tips-grid">
+                    <div class="tip-item">
+                        <i class="fas fa-ruler-combined"></i>
+                        <h3>Measure Twice</h3>
+                        <p>Use a soft measuring tape around the chest, waist, and hips for the best accuracy.</p>
+                    </div>
+                    <div class="tip-item">
+                        <i class="fas fa-arrows-alt-v"></i>
+                        <h3>Allow for Growth</h3>
+                        <p>Kids grow quickly! If you're between sizes, size up for extra months of wear.</p>
+                    </div>
+                    <div class="tip-item">
+                        <i class="fas fa-tshirt"></i>
+                        <h3>Check the Fabric</h3>
+                        <p>Stretch fabrics offer more flexibility. For structured pieces, opt for the larger size.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="cta-section">
+            <div class="container">
+                <h2>Ready to Find Their Next Favorite Outfit?</h2>
+                <p>Head back to the shop to explore new arrivals, seasonal picks, and everyday essentials.</p>
+                <a class="button solid" href="<?php echo $prefix; ?>pages/shop.php">Return to Shop</a>
+            </div>
+        </section>
+    </main>
+
+    <?php include __DIR__ . '/../partials/footer.php'; ?>
+    <button class="scroll-to-top" style="display: none;"><i class="fas fa-chevron-up"></i></button>
+
+    <script src="<?php echo $prefix; ?>assets/script.js"></script>
+</body>
+</html>

--- a/frontend/partials/footer.php
+++ b/frontend/partials/footer.php
@@ -3,7 +3,12 @@ $prefix = defined('KIDSTORE_FRONT_URL_PREFIX') ? KIDSTORE_FRONT_URL_PREFIX : '';
 $footerCategories = [];
 
 if (function_exists('kidstore_fetch_categories')) {
-    $footerCategories = kidstore_fetch_categories(true);
+    try {
+        $footerCategories = kidstore_fetch_categories(true);
+    } catch (Throwable $exception) {
+        $footerCategories = [];
+    }
+
     $footerCategories = array_values(array_filter(
         $footerCategories,
         static function ($category): bool {


### PR DESCRIPTION
## Summary
- add dedicated Size Guide, Shipping, Returns, and FAQ informational pages linked from the footer
- introduce shared styling helpers for informational layouts to keep the new pages consistent with the site
- make the footer category list resilient when the database connection is unavailable so informational pages still render

## Testing
- php -l frontend/pages/size-guide.php
- php -l frontend/pages/shipping.php
- php -l frontend/pages/returns.php
- php -l frontend/pages/faq.php
- php -S 0.0.0.0:8000 -t frontend & curl -s http://127.0.0.1:8000/pages/size-guide.php | grep -q "Find the Perfect Fit"
- php -S 0.0.0.0:8000 -t frontend & curl -s http://127.0.0.1:8000/pages/shipping.php | grep -q "Shipping Information"
- php -S 0.0.0.0:8000 -t frontend & curl -s http://127.0.0.1:8000/pages/returns.php | grep -q "Returns & Exchanges"
- php -S 0.0.0.0:8000 -t frontend & curl -s http://127.0.0.1:8000/pages/faq.php | grep -q "Frequently Asked Questions"

------
https://chatgpt.com/codex/tasks/task_e_68da53814d1c83249624d9f87773fd21