### PR TITLE
Link orders to shipping addresses

### DIFF
--- a/backend/pages/order_view.php
+++ b/backend/pages/order_view.php
@@ -43,10 +43,7 @@ if (isset($_SESSION['admin_flash'])) {
     $flashMessage = null;
 }
 
-$pdo = kidstore_get_pdo();
-$addressStmt = $pdo->prepare('SELECT * FROM tbl_shipping_addresses WHERE user_id = :user_id ORDER BY address_id DESC LIMIT 1');
-$addressStmt->execute(['user_id' => $order['user_id']]);
-$shipping = $addressStmt->fetch();
+$shipping = $order['shipping'] ?? null;
 
 $pageTitle = 'Order #' . str_pad((string) $orderId, 5, '0', STR_PAD_LEFT);
 $currentSection = 'orders';

--- a/frontend/actions/place_order.php
+++ b/frontend/actions/place_order.php
@@ -60,9 +60,9 @@ try {
     // Store latest address info on user profile for quick reference
     $_SESSION['customer_last_shipping'] = [
         'address_id' => $shippingAddressId,
-        'name' => $fields['name'],
+        'recipient_name' => $fields['name'],
         'phone' => $fields['phone'],
-        'address' => $fields['address'],
+        'address_line' => $fields['address'],
         'city' => $fields['city'],
         'postal_code' => $fields['postal_code'],
         'country' => $fields['country'],
@@ -72,6 +72,7 @@ try {
         'user_id' => $customer['user_id'],
         'items' => $cartItems,
         'payment_method' => $fields['payment_method'],
+        'shipping_address_id' => $shippingAddressId,
     ]);
 
     clearCart();

--- a/frontend/pages/order_confirmation.php
+++ b/frontend/pages/order_confirmation.php
@@ -17,9 +17,11 @@ if (!$order) {
 }
 
 
-$shipping = $_SESSION['customer_last_shipping'] ?? null;
+$sessionShipping = $_SESSION['customer_last_shipping'] ?? null;
 $total = $_SESSION['last_order_total'] ?? $order['total_price'] ?? 0;
 unset($_SESSION['customer_last_shipping'], $_SESSION['last_order_total']);
+
+$shipping = $order['shipping'] ?? $sessionShipping;
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -136,8 +138,8 @@ unset($_SESSION['customer_last_shipping'], $_SESSION['last_order_total']);
                 <?php if ($shipping): ?>
                     <div class="address-box">
                         <strong>Shipping to:</strong><br />
-                        <?= htmlspecialchars($shipping['name']) ?><br />
-                        <?= htmlspecialchars($shipping['address']) ?><br />
+                        <?= htmlspecialchars($shipping['recipient_name']) ?><br />
+                        <?= htmlspecialchars($shipping['address_line']) ?><br />
                         <?= htmlspecialchars($shipping['city']) ?>, <?= htmlspecialchars($shipping['postal_code']) ?><br />
                         <?= htmlspecialchars($shipping['country']) ?><br />
                         Phone: <?= htmlspecialchars($shipping['phone']) ?>

--- a/kidstore.sql
+++ b/kidstore.sql
@@ -76,20 +76,22 @@ DROP TABLE IF EXISTS `tbl_orders`;
 CREATE TABLE IF NOT EXISTS `tbl_orders` (
   `order_id` int NOT NULL AUTO_INCREMENT,
   `user_id` int NOT NULL,
+  `shipping_address_id` int DEFAULT NULL,
   `total_price` decimal(10,2) NOT NULL,
   `status` enum('pending','processing','shipped','delivered','cancelled') DEFAULT 'pending',
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`order_id`),
-  KEY `user_id` (`user_id`)
+  KEY `user_id` (`user_id`),
+  KEY `shipping_address_id` (`shipping_address_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 --
 -- Dumping data for table `tbl_orders`
 --
 
-INSERT INTO `tbl_orders` (`order_id`, `user_id`, `total_price`, `status`, `created_at`, `updated_at`) VALUES
-(1, 2, 49.98, 'pending', '2025-09-26 16:34:24', '2025-09-26 16:34:24');
+INSERT INTO `tbl_orders` (`order_id`, `user_id`, `shipping_address_id`, `total_price`, `status`, `created_at`, `updated_at`) VALUES
+(1, 2, 1, 49.98, 'pending', '2025-09-26 16:34:24', '2025-09-26 16:34:24');
 
 -- --------------------------------------------------------
 
@@ -274,7 +276,8 @@ ALTER TABLE `tbl_cart_items`
 -- Constraints for table `tbl_orders`
 --
 ALTER TABLE `tbl_orders`
-  ADD CONSTRAINT `tbl_orders_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `tbl_users` (`user_id`) ON DELETE CASCADE;
+  ADD CONSTRAINT `tbl_orders_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `tbl_users` (`user_id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `tbl_orders_ibfk_2` FOREIGN KEY (`shipping_address_id`) REFERENCES `tbl_shipping_addresses` (`address_id`) ON DELETE SET NULL;
 
 --
 -- Constraints for table `tbl_order_items`

--- a/migrations/20240927_add_shipping_address_to_orders.sql
+++ b/migrations/20240927_add_shipping_address_to_orders.sql
@@ -1,0 +1,17 @@
+ALTER TABLE tbl_orders
+    ADD COLUMN shipping_address_id INT NULL AFTER user_id,
+    ADD KEY shipping_address_id (shipping_address_id);
+
+UPDATE tbl_orders o
+INNER JOIN (
+    SELECT user_id, MAX(address_id) AS address_id
+    FROM tbl_shipping_addresses
+    GROUP BY user_id
+) latest ON latest.user_id = o.user_id
+SET o.shipping_address_id = latest.address_id
+WHERE o.shipping_address_id IS NULL;
+
+ALTER TABLE tbl_orders
+    ADD CONSTRAINT tbl_orders_ibfk_2 FOREIGN KEY (shipping_address_id)
+        REFERENCES tbl_shipping_addresses (address_id)
+        ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- add a shipping_address_id foreign key to tbl_orders and backfill existing data
- persist the selected shipping address when creating orders and include it in order summaries
- display shipping details from the stored address in both admin and customer views

## Testing
- php -l includes/orders.php
- php -l frontend/actions/place_order.php
- php -l frontend/pages/order_confirmation.php
- php -l backend/pages/order_view.php

------
https://chatgpt.com/codex/tasks/task_e_68dfc6f428a48324ab538593f0e22ef3