### PR TITLE
Verify PayWay callback signatures before finalizing orders

### DIFF
--- a/abapayway/PayWayApiCheckout.php
+++ b/abapayway/PayWayApiCheckout.php
@@ -22,6 +22,182 @@ class PayWayApiCheckout
     }
 
     /**
+     * Generate the callback hash as documented by PayWay.
+     *
+     * The response hash is calculated from the transaction ID, status, amount,
+     * currency, request timestamp, and merchant ID using the same HMAC-SHA512
+     * signature mechanism that is used during purchase initiation.
+     *
+     * @param array<string, mixed> $payload Raw callback payload.
+     */
+    public static function buildCallbackHash(array $payload): string
+    {
+        $tranId = trim((string) ($payload['tran_id'] ?? $payload['transaction_id'] ?? $payload['transactionId'] ?? ''));
+        $status = trim((string) ($payload['status'] ?? $payload['payment_status'] ?? $payload['result'] ?? ''));
+        $amount = trim((string) ($payload['amount'] ?? $payload['total_amount'] ?? $payload['payment_amount'] ?? ''));
+        $currency = trim((string) ($payload['currency'] ?? $payload['currency_code'] ?? ''));
+        $requestTime = trim((string) (
+            $payload['req_time']
+            ?? $payload['request_time']
+            ?? $payload['requestTime']
+            ?? $payload['res_time']
+            ?? $payload['response_time']
+            ?? $payload['timestamp']
+            ?? ''
+        ));
+
+        $merchantId = trim((string) ($payload['merchant_id'] ?? ABA_PAYWAY_MERCHANT_ID));
+
+        $signaturePayload = $tranId . $status . $amount . $currency . $requestTime . $merchantId;
+
+        if ($signaturePayload === '') {
+            return '';
+        }
+
+        return self::getHash($signaturePayload);
+    }
+
+    /**
+     * Determine if the helper has been configured with real credentials.
+     */
+    public static function isConfigured(): bool
+    {
+        $apiKey = trim((string) ABA_PAYWAY_API_KEY);
+        $merchantId = trim((string) ABA_PAYWAY_MERCHANT_ID);
+
+        return $apiKey !== ''
+            && $merchantId !== ''
+            && stripos($apiKey, 'YOUR_ABA_PAYWAY_API_KEY') === false
+            && stripos($merchantId, 'YOUR_ABA_PAYWAY_MERCHANT_ID') === false;
+    }
+
+    /**
+     * Normalize a monetary value to the format PayWay expects (two decimals).
+     */
+    public static function normalizeAmount(?string $amount): string
+    {
+        if ($amount === null || $amount === '') {
+            return '0.00';
+        }
+
+        return number_format((float) $amount, 2, '.', '');
+    }
+
+    /**
+     * Retrieve the status verification endpoint.
+     */
+    public static function getVerificationUrl(): string
+    {
+        $base = rtrim(dirname(ABA_PAYWAY_API_URL), '/');
+
+        return $base . '/check-transaction';
+    }
+
+    /**
+     * Execute a transaction status check with PayWay.
+     *
+     * @return array{http_code:int,body:array<string,mixed>}|null
+     */
+    public static function checkTransactionStatus(string $tranId): ?array
+    {
+        if ($tranId === '' || !self::isConfigured() || !function_exists('curl_init')) {
+            return null;
+        }
+
+        $reqTime = (string) time();
+        $payload = [
+            'req_time' => $reqTime,
+            'merchant_id' => ABA_PAYWAY_MERCHANT_ID,
+            'tran_id' => $tranId,
+        ];
+
+        $payload['hash'] = self::getHash($reqTime . ABA_PAYWAY_MERCHANT_ID . $tranId);
+
+        $jsonPayload = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($jsonPayload === false) {
+            return null;
+        }
+
+        $ch = curl_init(self::getVerificationUrl());
+        if ($ch === false) {
+            return null;
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $jsonPayload,
+            CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 15,
+        ]);
+
+        $body = curl_exec($ch);
+        $errorNumber = curl_errno($ch);
+        $errorMessage = curl_error($ch);
+        $statusCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($body === false || $errorNumber !== 0) {
+            if ($errorMessage !== '') {
+                error_log('PayWay status verification failed: ' . $errorMessage);
+            }
+
+            return null;
+        }
+
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded)) {
+            error_log('PayWay status verification returned an unexpected payload.');
+
+            return null;
+        }
+
+        return [
+            'http_code' => $statusCode,
+            'body' => $decoded,
+        ];
+    }
+
+    /**
+     * Determine if the queried transaction is successful.
+     */
+    public static function confirmTransactionStatus(string $tranId, ?string $expectedAmount = null): ?bool
+    {
+        $response = self::checkTransactionStatus($tranId);
+        if ($response === null) {
+            return null;
+        }
+
+        $data = $response['body'];
+        $statusRaw = (string) ($data['status'] ?? $data['payment_status'] ?? $data['result'] ?? '');
+        $statusNormalized = strtolower(trim($statusRaw));
+
+        $successStatuses = ['0', 'success', 'completed', 'approved', 'paid', 'true'];
+        $isSuccessful = $statusNormalized !== '' && in_array($statusNormalized, $successStatuses, true);
+
+        if (!$isSuccessful) {
+            $code = isset($data['code']) ? (string) $data['code'] : '';
+            if ($code === '0' || (isset($data['status']) && (string) $data['status'] === '0')) {
+                $isSuccessful = true;
+            }
+        }
+
+        if ($expectedAmount !== null && $expectedAmount !== '') {
+            $remoteAmount = trim((string) ($data['amount'] ?? $data['total_amount'] ?? $data['total'] ?? ''));
+            if ($remoteAmount !== '') {
+                $expectedNormalized = self::normalizeAmount($expectedAmount);
+                $remoteNormalized = self::normalizeAmount($remoteAmount);
+
+                if ($expectedNormalized !== $remoteNormalized) {
+                    return false;
+                }
+            }
+        }
+
+        return $isSuccessful;
+    }
+
+    /**
      * Retrieve the configured API URL.
      */
     public static function getApiUrl(): string

--- a/frontend/actions/payway_callback.php
+++ b/frontend/actions/payway_callback.php
@@ -2,10 +2,12 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../includes/bootstrap.php';
+require_once __DIR__ . '/../../abapayway/PayWayApiCheckout.php';
 
 $payload = $_SERVER['REQUEST_METHOD'] === 'POST' ? $_POST : $_GET;
 
-$statusRaw = strtolower(trim((string) ($payload['status'] ?? $payload['payment_status'] ?? $payload['result'] ?? '')));
+$statusOriginal = (string) ($payload['status'] ?? $payload['payment_status'] ?? $payload['result'] ?? '');
+$statusRaw = strtolower(trim($statusOriginal));
 $tranId = trim((string) ($payload['tran_id'] ?? $payload['transaction_id'] ?? ''));
 $returnParamsRaw = $payload['return_params'] ?? $payload['returnParams'] ?? null;
 
@@ -37,11 +39,43 @@ if ($orderId <= 0) {
 $expectedTran = is_array($paywaySession) ? (string) ($paywaySession['tran_id'] ?? '') : '';
 $tranMismatch = $expectedTran !== '' && $tranId !== '' && !hash_equals($expectedTran, $tranId);
 
+$hashValue = trim((string) ($payload['hash'] ?? $payload['signature'] ?? $payload['hash_value'] ?? ''));
+if ($hashValue === '') {
+    error_log(sprintf('PayWay callback missing signature for order #%d (tran %s).', $orderId, $tranId ?: 'unknown'));
+    $_SESSION['checkout_error'] = 'We could not verify the PayWay payment signature. Please try again or contact support.';
+    unset($_SESSION['payway_checkout'], $_SESSION['payway_pending_order_id']);
+    header('Location: ../pages/checkout.php');
+    exit;
+}
+
+$expectedHash = PayWayApiCheckout::buildCallbackHash($payload);
+if ($expectedHash === '' || !hash_equals($expectedHash, $hashValue)) {
+    error_log(sprintf('PayWay callback signature mismatch for order #%d (tran %s).', $orderId, $tranId ?: 'unknown'));
+    $_SESSION['checkout_error'] = 'We could not verify the PayWay payment signature. Please contact support with order #' . $orderId . '.';
+    unset($_SESSION['payway_checkout'], $_SESSION['payway_pending_order_id']);
+    header('Location: ../pages/checkout.php');
+    exit;
+}
+
+$payloadAmount = trim((string) ($payload['amount'] ?? $payload['total_amount'] ?? $payload['payment_amount'] ?? ''));
+$sessionAmount = is_array($paywaySession) ? (string) ($paywaySession['amount'] ?? '') : '';
+$expectedAmount = $sessionAmount !== '' ? $sessionAmount : $payloadAmount;
+
 $successStatuses = ['0', 'success', 'completed', 'approved', 'true'];
 $isSuccessful = !$tranMismatch && ($statusRaw === '' ? false : in_array($statusRaw, $successStatuses, true));
 
 if ($statusRaw === '' && !$isSuccessful && !$tranMismatch) {
     $isSuccessful = isset($payload['success']) && (bool) $payload['success'];
+}
+
+if (!$tranMismatch && $tranId !== '') {
+    $verified = PayWayApiCheckout::confirmTransactionStatus($tranId, $expectedAmount !== '' ? $expectedAmount : null);
+    if ($verified === true) {
+        $isSuccessful = true;
+    } elseif ($verified === false) {
+        error_log(sprintf('PayWay verification reported failure for order #%d (tran %s).', $orderId, $tranId));
+        $isSuccessful = false;
+    }
 }
 
 if ($isSuccessful) {


### PR DESCRIPTION
## Summary
- add helper methods to rebuild PayWay callback hashes and query transaction status via the verification API
- require and validate the PayWay callback signature before updating orders, logging and aborting on mismatches
- cross-check successful callbacks against PayWay's transaction status endpoint when available

## Testing
- php -l abapayway/PayWayApiCheckout.php
- php -l frontend/actions/payway_callback.php

------
https://chatgpt.com/codex/tasks/task_e_68e1551ac1e883249a0f9f1cef2faef1