### PR TITLE
Use PayWay accessors for environment-aware checkout

### DIFF
--- a/frontend/actions/initiate_abapayway.php
+++ b/frontend/actions/initiate_abapayway.php
@@ -85,17 +85,25 @@ try {
     $formattedAmount = number_format((float) $order['total'], 2, '.', '');
     $transactionId = sprintf('order-%d-%s', (int) $order['order_id'], bin2hex(random_bytes(4)));
     $reqTime = (string) time();
+    $merchantId = PayWayApiCheckout::getMerchantId();
+    $apiUrl = PayWayApiCheckout::getApiUrl();
 
     $returnParams = json_encode([
         'order_id' => (int) $order['order_id'],
         'tran_id' => $transactionId,
+        'merchant_id' => $merchantId,
     ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
     if ($returnParams === false) {
-        $returnParams = sprintf('{"order_id":%d,"tran_id":"%s"}', (int) $order['order_id'], addslashes($transactionId));
+        $returnParams = sprintf(
+            '{"order_id":%d,"tran_id":"%s","merchant_id":"%s"}',
+            (int) $order['order_id'],
+            addslashes($transactionId),
+            addslashes($merchantId)
+        );
     }
 
-    $hashInput = $reqTime . ABA_PAYWAY_MERCHANT_ID . $transactionId . $formattedAmount . $firstName . $lastName . $fields['email'] . $fields['phone'] . $returnParams;
+    $hashInput = $reqTime . $merchantId . $transactionId . $formattedAmount . $firstName . $lastName . $fields['email'] . $fields['phone'] . $returnParams;
     $hash = PayWayApiCheckout::getHash($hashInput);
 
     $_SESSION['payway_checkout'] = [
@@ -109,6 +117,8 @@ try {
         'phone' => $fields['phone'],
         'return_params' => $returnParams,
         'hash' => $hash,
+        'merchant_id' => $merchantId,
+        'api_url' => $apiUrl,
     ];
 
     $_SESSION['payway_pending_order_id'] = (int) $order['order_id'];

--- a/frontend/pages/payway_checkout.php
+++ b/frontend/pages/payway_checkout.php
@@ -37,7 +37,15 @@ $firstName = (string) $paywaySession['first_name'];
 $lastName = (string) $paywaySession['last_name'];
 $email = (string) $paywaySession['email'];
 $phone = (string) $paywaySession['phone'];
-$hashInput = $reqTime . ABA_PAYWAY_MERCHANT_ID . $tranId . $amount . $firstName . $lastName . $email . $phone . $returnParams;
+$merchantId = trim((string) ($paywaySession['merchant_id'] ?? ''));
+if ($merchantId === '') {
+    $merchantId = PayWayApiCheckout::getMerchantId();
+}
+$apiUrl = trim((string) ($paywaySession['api_url'] ?? ''));
+if ($apiUrl === '') {
+    $apiUrl = PayWayApiCheckout::getApiUrl();
+}
+$hashInput = $reqTime . $merchantId . $tranId . $amount . $firstName . $lastName . $email . $phone . $returnParams;
 $hash = PayWayApiCheckout::getHash($hashInput);
 $_SESSION['payway_checkout']['hash'] = $hash;
 
@@ -199,7 +207,7 @@ $itemsEncoded = base64_encode($itemsJson);
         </div>
     </section>
 </main>
-<form method="POST" target="aba_webservice" action="<?= htmlspecialchars(PayWayApiCheckout::getApiUrl(), ENT_QUOTES, 'UTF-8'); ?>" id="aba_merchant_request">
+<form method="POST" target="aba_webservice" action="<?= htmlspecialchars($apiUrl, ENT_QUOTES, 'UTF-8'); ?>" id="aba_merchant_request">
     <input type="hidden" name="hash" value="<?= htmlspecialchars($hash, ENT_QUOTES, 'UTF-8'); ?>" />
     <input type="hidden" name="tran_id" value="<?= htmlspecialchars($tranId, ENT_QUOTES, 'UTF-8'); ?>" />
     <input type="hidden" name="amount" value="<?= htmlspecialchars($amount, ENT_QUOTES, 'UTF-8'); ?>" />
@@ -209,7 +217,7 @@ $itemsEncoded = base64_encode($itemsJson);
     <input type="hidden" name="email" value="<?= htmlspecialchars($email, ENT_QUOTES, 'UTF-8'); ?>" />
     <input type="hidden" name="items" value="<?= htmlspecialchars($itemsEncoded, ENT_QUOTES, 'UTF-8'); ?>" />
     <input type="hidden" name="return_params" value='<?= htmlspecialchars($returnParams, ENT_QUOTES, 'UTF-8'); ?>' />
-    <input type="hidden" name="merchant_id" value="<?= htmlspecialchars(ABA_PAYWAY_MERCHANT_ID, ENT_QUOTES, 'UTF-8'); ?>" />
+    <input type="hidden" name="merchant_id" value="<?= htmlspecialchars($merchantId, ENT_QUOTES, 'UTF-8'); ?>" />
     <input type="hidden" name="req_time" value="<?= htmlspecialchars($reqTime, ENT_QUOTES, 'UTF-8'); ?>" />
     <input type="hidden" name="return_url" value="<?= htmlspecialchars($callbackUrl, ENT_QUOTES, 'UTF-8'); ?>" />
 </form>


### PR DESCRIPTION
## Summary
- use PayWayApiCheckout accessors when generating PayWay session metadata and hashing data
- persist the resolved API URL and merchant ID in the session for use during checkout
- update the checkout form to consume stored PayWay settings and avoid direct constant usage

## Testing
- php -l frontend/actions/initiate_abapayway.php
- php -l frontend/pages/payway_checkout.php

------
https://chatgpt.com/codex/tasks/task_e_68e15c60b5148324aaf0d659ecf3f05b